### PR TITLE
feat(protocols): add base simulation protocol interfaces

### DIFF
--- a/src/plume_nav_sim/protocols/__init__.py
+++ b/src/plume_nav_sim/protocols/__init__.py
@@ -1,0 +1,15 @@
+"""Protocol definitions for plume navigation simulation components."""
+
+from .navigator import NavigatorProtocol
+from .sensor import SensorProtocol
+from .plume_model import PlumeModelProtocol
+from .wind_field import WindFieldProtocol
+from .performance_monitor import PerformanceMonitorProtocol
+
+__all__ = [
+    "NavigatorProtocol",
+    "SensorProtocol",
+    "PlumeModelProtocol",
+    "WindFieldProtocol",
+    "PerformanceMonitorProtocol",
+]

--- a/src/plume_nav_sim/protocols/navigator.py
+++ b/src/plume_nav_sim/protocols/navigator.py
@@ -1,0 +1,27 @@
+"""Navigation protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any, runtime_checkable
+
+
+@runtime_checkable
+class NavigatorProtocol(Protocol):
+    """Structural interface for navigation controllers.
+
+    Implementations manage agent motion and internal state updates during a
+    simulation. Concrete navigators should provide deterministic behavior
+    and expose their state for inspection.
+    """
+
+    def reset(self) -> None:
+        """Reset the navigator to its initial state."""
+
+    def step(self, dt: float) -> None:
+        """Advance the navigator state by ``dt`` seconds."""
+
+    def get_state(self) -> Dict[str, Any]:
+        """Return a snapshot of the navigator's current state."""
+
+
+__all__ = ["NavigatorProtocol"]

--- a/src/plume_nav_sim/protocols/performance_monitor.py
+++ b/src/plume_nav_sim/protocols/performance_monitor.py
@@ -1,0 +1,22 @@
+"""Performance monitoring protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any, runtime_checkable
+
+
+@runtime_checkable
+class PerformanceMonitorProtocol(Protocol):
+    """Interface for collecting simulation performance metrics."""
+
+    def record_step(self, data: Dict[str, Any]) -> None:
+        """Record metrics for a single simulation step."""
+
+    def record_episode(self, data: Dict[str, Any]) -> None:
+        """Record aggregated metrics for an episode."""
+
+    def get_metrics(self) -> Dict[str, float]:
+        """Return accumulated performance statistics."""
+
+
+__all__ = ["PerformanceMonitorProtocol"]

--- a/src/plume_nav_sim/protocols/plume_model.py
+++ b/src/plume_nav_sim/protocols/plume_model.py
@@ -1,0 +1,22 @@
+"""Plume model protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class PlumeModelProtocol(Protocol):
+    """Interface for concentration field models."""
+
+    def concentration_at(self, positions: Sequence[Sequence[float]]) -> Sequence[float]:
+        """Return plume concentration at ``positions``."""
+
+    def step(self, dt: float) -> None:
+        """Advance the plume model by ``dt`` seconds."""
+
+    def reset(self) -> None:
+        """Reset the plume model state."""
+
+
+__all__ = ["PlumeModelProtocol"]

--- a/src/plume_nav_sim/protocols/sensor.py
+++ b/src/plume_nav_sim/protocols/sensor.py
@@ -1,0 +1,23 @@
+"""Sensor protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, Any, runtime_checkable
+
+
+@runtime_checkable
+class SensorProtocol(Protocol):
+    """Interface for plume sensing components.
+
+    Sensors provide detection or measurement capabilities for agents based on
+    the underlying plume model state.
+    """
+
+    def detect(self, plume_state: Any, positions: Sequence[Sequence[float]]) -> Sequence[bool]:
+        """Return detection events for agents at ``positions``."""
+
+    def measure(self, plume_state: Any, positions: Sequence[Sequence[float]]) -> Sequence[float]:
+        """Return scalar measurements for agents at ``positions``."""
+
+
+__all__ = ["SensorProtocol"]

--- a/src/plume_nav_sim/protocols/wind_field.py
+++ b/src/plume_nav_sim/protocols/wind_field.py
@@ -1,0 +1,22 @@
+"""Wind field protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, Tuple, runtime_checkable
+
+
+@runtime_checkable
+class WindFieldProtocol(Protocol):
+    """Interface for wind field models affecting plume transport."""
+
+    def velocity_at(self, positions: Sequence[Sequence[float]]) -> Sequence[Tuple[float, float]]:
+        """Return wind velocity vectors at ``positions``."""
+
+    def step(self, dt: float) -> None:
+        """Advance the wind field by ``dt`` seconds."""
+
+    def reset(self) -> None:
+        """Reset the wind field state."""
+
+
+__all__ = ["WindFieldProtocol"]

--- a/tests/protocols/test_simulation_protocols.py
+++ b/tests/protocols/test_simulation_protocols.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Dict, Any
+
+import pytest
+from mypy import api as mypy_api
+
+from plume_nav_sim import protocols as sim_protocols
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
+    "NavigatorProtocol": {
+        "methods": {
+            "reset": lambda self: None,
+            "step": lambda self, dt: None,
+            "get_state": lambda self: {},
+        },
+        "missing": "step",
+    },
+    "SensorProtocol": {
+        "methods": {
+            "detect": lambda self, plume_state, positions: [False],
+            "measure": lambda self, plume_state, positions: [0.0],
+        },
+        "missing": "measure",
+    },
+    "PlumeModelProtocol": {
+        "methods": {
+            "concentration_at": lambda self, positions: [0.0],
+            "step": lambda self, dt: None,
+            "reset": lambda self: None,
+        },
+        "missing": "step",
+    },
+    "WindFieldProtocol": {
+        "methods": {
+            "velocity_at": lambda self, positions: [(0.0, 0.0)],
+            "step": lambda self, dt: None,
+            "reset": lambda self: None,
+        },
+        "missing": "step",
+    },
+    "PerformanceMonitorProtocol": {
+        "methods": {
+            "record_step": lambda self, data: None,
+            "record_episode": lambda self, data: None,
+            "get_metrics": lambda self: {"dummy": 0.0},
+        },
+        "missing": "record_episode",
+    },
+}
+
+
+@pytest.mark.parametrize("protocol_name,spec", PROTOCOL_SPECS.items())
+def test_protocol_structural_compatibility(protocol_name: str, spec: Dict[str, Any]) -> None:
+    logger.info("Validating positive case for %s", protocol_name)
+    protocol_cls = getattr(sim_protocols, protocol_name)
+    dummy_cls = type(f"Dummy{protocol_name.replace('Protocol', '')}", (), spec["methods"])
+    instance = dummy_cls()
+    assert isinstance(instance, protocol_cls)
+
+
+@pytest.mark.parametrize("protocol_name,spec", PROTOCOL_SPECS.items())
+def test_protocol_missing_method_runtime(protocol_name: str, spec: Dict[str, Any]) -> None:
+    logger.info("Validating runtime failure for %s", protocol_name)
+    protocol_cls = getattr(sim_protocols, protocol_name)
+    methods = {name: fn for name, fn in spec["methods"].items() if name != spec["missing"]}
+    incomplete_cls = type(f"Incomplete{protocol_name.replace('Protocol', '')}", (), methods)
+    instance = incomplete_cls()
+    assert not isinstance(instance, protocol_cls)
+
+
+@pytest.mark.parametrize("protocol_name", PROTOCOL_SPECS.keys())
+def test_protocol_missing_method_mypy(protocol_name: str) -> None:
+    logger.info("Running mypy negative test for %s", protocol_name)
+    class_name = f"Incomplete{protocol_name.replace('Protocol', '')}"
+    snippet = f"""
+from plume_nav_sim.protocols import {protocol_name}
+class {class_name}:
+    pass
+
+def accept(obj: {protocol_name}) -> None: ...
+accept({class_name}())
+"""
+    stdout, stderr, exit_status = mypy_api.run(["--strict", "-c", snippet])
+    logger.info("mypy output for %s: %s", protocol_name, stdout.strip())
+    assert exit_status != 0


### PR DESCRIPTION
## Summary
- add protocol interfaces for navigator, sensor, plume model, wind field, and performance monitor
- verify structural compliance with new protocol tests

## Testing
- `pytest -o addopts="" tests/protocols/test_simulation_protocols.py`

------
https://chatgpt.com/codex/tasks/task_e_68afaf3063e08320a5bccd236a398c78