### PR TITLE
refactor: centralize NavigatorProtocol and harden adapters

### DIFF
--- a/src/plume_nav_sim/core/navigator.py
+++ b/src/plume_nav_sim/core/navigator.py
@@ -76,7 +76,8 @@ from typing import Optional, Union, Tuple, List, Any, Dict, ClassVar
 import numpy as np
 
 # Core protocol and controller imports
-from .protocols import NavigatorProtocol, NavigatorFactory as BaseNavigatorFactory
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
+from .protocols import NavigatorFactory as BaseNavigatorFactory
 from .protocols import (
     PositionType, PositionsType, OrientationType, OrientationsType,
     SpeedType, SpeedsType, ConfigType, ObservationHookType, 

--- a/src/plume_nav_sim/core/protocols.py
+++ b/src/plume_nav_sim/core/protocols.py
@@ -33,6 +33,9 @@ import numpy as np
 import warnings
 import inspect
 
+# Use shared NavigatorProtocol definition
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
+
 # Hydra imports for configuration integration
 try:
     from omegaconf import DictConfig
@@ -93,7 +96,7 @@ except ImportError:
 
 
 @runtime_checkable
-class NavigatorProtocol(Protocol):
+class _LegacyNavigatorProtocol(Protocol):
     """
     Protocol defining the structural interface for navigator controllers.
     

--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -132,7 +132,7 @@ except ImportError:
 
 # Type checking imports
 if TYPE_CHECKING:
-    from ..core.protocols import NavigatorProtocol
+    from plume_nav_sim.protocols.navigator import NavigatorProtocol
     from ..envs.plume_navigation_env import PlumeNavigationEnv
 
 

--- a/src/plume_nav_sim/examples/__init__.py
+++ b/src/plume_nav_sim/examples/__init__.py
@@ -92,7 +92,8 @@ import importlib
 import argparse
 
 # Core system imports for agent integration
-from ..core.protocols import NavigatorProtocol, PlumeModelProtocol, WindFieldProtocol, SensorProtocol
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
+from ..core.protocols import PlumeModelProtocol, WindFieldProtocol, SensorProtocol
 from ..core.simulation import SimulationContext, run_simulation
 from ..models import create_plume_model, create_wind_field, create_sensors, get_model_registry
 

--- a/src/plume_nav_sim/examples/agents/__init__.py
+++ b/src/plume_nav_sim/examples/agents/__init__.py
@@ -89,17 +89,21 @@ import numpy as np
 
 # Core protocol imports for type safety and validation
 try:
-    from ...core.protocols import NavigatorProtocol, NavigatorFactory
+    from plume_nav_sim.protocols.navigator import NavigatorProtocol
+    from ...core.protocols import NavigatorFactory
     from ...core.protocols import PlumeModelProtocol, SensorProtocol
     PROTOCOLS_AVAILABLE = True
 except ImportError:
     # Fallback for development/testing scenarios
-    NavigatorProtocol = object
+    NavigatorProtocol = None  # type: ignore
     NavigatorFactory = object
     PlumeModelProtocol = object
     SensorProtocol = object
     PROTOCOLS_AVAILABLE = False
-    warnings.warn("Core protocols not available. Some functionality may be limited.", ImportWarning)
+    warnings.warn(
+        "Core protocols not available. Some functionality may be limited.",
+        ImportWarning,
+    )
 
 # Configuration and simulation imports
 try:

--- a/src/plume_nav_sim/examples/agents/casting_agent.py
+++ b/src/plume_nav_sim/examples/agents/casting_agent.py
@@ -83,12 +83,14 @@ import numpy as np
 
 # Core navigation protocol imports
 try:
-    from ...core.protocols import NavigatorProtocol, SensorProtocol
+    from plume_nav_sim.protocols.navigator import NavigatorProtocol
+    from ...core.protocols import SensorProtocol
     from ...core.controllers import SingleAgentController
     CORE_AVAILABLE = True
 except ImportError:
     # Fallback during migration
-    from plume_nav_sim.core.protocols import NavigatorProtocol, SensorProtocol
+    NavigatorProtocol = None  # type: ignore
+    from plume_nav_sim.core.protocols import SensorProtocol
     from plume_nav_sim.core.controllers import SingleAgentController
     CORE_AVAILABLE = True
 

--- a/src/plume_nav_sim/examples/agents/infotaxis_agent.py
+++ b/src/plume_nav_sim/examples/agents/infotaxis_agent.py
@@ -76,31 +76,12 @@ import json
 
 # Core protocol and controller imports
 try:
-    from ...core.protocols import NavigatorProtocol, PositionType, ConfigType
+    from plume_nav_sim.protocols.navigator import NavigatorProtocol
+    from ...core.protocols import PositionType, ConfigType
     from ...core.controllers import SingleAgentController
     PROTOCOLS_AVAILABLE = True
 except ImportError:
-    # Fallback during development
-    from typing import Protocol
-    class NavigatorProtocol(Protocol):
-        """Fallback NavigatorProtocol definition."""
-        @property
-        def positions(self) -> np.ndarray: ...
-        @property
-        def orientations(self) -> np.ndarray: ...
-        @property
-        def speeds(self) -> np.ndarray: ...
-        @property
-        def max_speeds(self) -> np.ndarray: ...
-        @property
-        def angular_velocities(self) -> np.ndarray: ...
-        @property
-        def num_agents(self) -> int: ...
-        def reset(self, **kwargs: Any) -> None: ...
-        def step(self, env_array: np.ndarray, dt: float = 1.0) -> None: ...
-        def sample_odor(self, env_array: np.ndarray) -> float: ...
-        def sample_multiple_sensors(self, env_array: np.ndarray, **kwargs) -> np.ndarray: ...
-    
+    NavigatorProtocol = None  # type: ignore
     SingleAgentController = object
     PositionType = Tuple[float, float]
     ConfigType = Dict[str, Any]

--- a/src/plume_nav_sim/examples/agents/reactive_agent.py
+++ b/src/plume_nav_sim/examples/agents/reactive_agent.py
@@ -96,7 +96,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 # Core protocol and controller imports for NavigatorProtocol compliance
-from ...core.protocols import NavigatorProtocol
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
 from ...core.controllers import SingleAgentController
 
 # Sensor abstraction layer for gradient-based navigation

--- a/src/plume_nav_sim/utils/navigator_utils.py
+++ b/src/plume_nav_sim/utils/navigator_utils.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from plume_nav_sim.core.protocols import NavigatorProtocol
+    from plume_nav_sim.protocols.navigator import NavigatorProtocol
     from plume_nav_sim.core.navigator import Navigator
 else:
     # At runtime, import lazily to avoid circular imports
@@ -51,12 +51,11 @@ def _get_navigator_protocol():
     global NavigatorProtocol
     if NavigatorProtocol is None:
         try:
-            from plume_nav_sim.core.protocols import NavigatorProtocol as _NavigatorProtocol
+            from plume_nav_sim.protocols.navigator import NavigatorProtocol as _NavigatorProtocol
             NavigatorProtocol = _NavigatorProtocol
-        except ImportError:
-            # If still can't import, create a dummy class
-            class NavigatorProtocol:
-                pass
+        except ImportError as e:
+            logger.debug("NavigatorProtocol import failed: %s", e)
+            raise NotImplementedError("NavigatorProtocol is required but missing") from e
     return NavigatorProtocol
 
 def _get_navigator():

--- a/tests/test_protocol_refactor.py
+++ b/tests/test_protocol_refactor.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from plume_nav_sim.api.navigation import from_legacy
+from plume_nav_sim.core import protocols as core_protocols
+from plume_nav_sim.protocols import navigator as navigator_mod
+
+
+def test_core_protocols_navigator_protocol_is_global():
+    assert core_protocols.NavigatorProtocol is navigator_mod.NavigatorProtocol
+
+
+class MissingStepNavigator:
+    positions = np.zeros((1, 2))
+    orientations = np.zeros(1)
+
+    def reset(self):
+        pass
+
+
+class DummyPlume:
+    pass
+
+
+def test_legacy_adapter_missing_step(caplog):
+    nav = MissingStepNavigator()
+    plume = DummyPlume()
+    adapter = from_legacy(nav, plume, max_episode_steps=10, render_mode=None)
+
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(NotImplementedError):
+            adapter.step(np.zeros(2))
+
+    assert "missing step method" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- import NavigatorProtocol from `plume_nav_sim.protocols.navigator` and remove local class copies
- add debug logging and `NotImplementedError` in legacy adapters
- cover NavigatorProtocol import and legacy adapter with targeted tests

## Testing
- `pytest -c /dev/null tests/test_protocol_refactor.py::test_core_protocols_navigator_protocol_is_global tests/test_protocol_refactor.py::test_legacy_adapter_missing_step -q`
- `pytest -c /dev/null -q` *(fails: libGL.so.1: cannot open shared object file; test dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0254b188320b30197e7fe1006d3