### PR TITLE
feat: centralize sensor protocol and add adapter logging

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -111,44 +111,10 @@ import numpy as np
 
 # Core protocol imports
 from .protocols import NavigatorProtocol, BoundaryPolicyProtocol, SourceProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Boundary policy factory import
 from .boundaries import create_boundary_policy
-
-# Sensor protocol definitions - basic implementations for modular architecture
-from typing import Protocol, runtime_checkable
-from abc import ABC, abstractmethod
-
-@runtime_checkable
-class SensorProtocol(Protocol):
-    """
-    Protocol defining the interface for sensor implementations.
-    
-    This protocol enables modular perception systems where agents can
-    perceive the environment through configurable sensors rather than
-    direct field access, supporting the agent-agnostic design.
-    """
-    
-    def sample(self, plume_state: np.ndarray, positions: np.ndarray) -> np.ndarray:
-        """
-        Sample sensor readings at specified positions.
-        
-        Args:
-            plume_state: Current environmental state (e.g., odor field)
-            positions: Agent positions to sample at, shape (n_agents, 2)
-            
-        Returns:
-            np.ndarray: Sensor readings for each position
-        """
-        ...
-    
-    def configure(self, **kwargs) -> None:
-        """Configure sensor parameters."""
-        ...
-    
-    def reset(self) -> None:
-        """Reset sensor state (e.g., clear history)."""
-        ...
 
 
 # Basic sensor implementations for interim use until full sensor system is available

--- a/src/plume_nav_sim/core/sensors/base_sensor.py
+++ b/src/plume_nav_sim/core/sensors/base_sensor.py
@@ -76,7 +76,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 # Core protocol imports
-from ..protocols import SensorProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Hydra integration for configuration management
 try:

--- a/src/plume_nav_sim/core/sensors/binary_sensor.py
+++ b/src/plume_nav_sim/core/sensors/binary_sensor.py
@@ -51,19 +51,14 @@ Examples:
 from __future__ import annotations
 import time
 import warnings
-from typing import Protocol, runtime_checkable, Optional, Union, Dict, Any, List, Tuple
+from typing import Optional, Union, Dict, Any, List, Tuple
 from dataclasses import dataclass, field
 import numpy as np
 
 # Core protocol imports
-try:
-    from ..protocols import NavigatorProtocol, SensorProtocol
-    PROTOCOLS_AVAILABLE = True
-except ImportError:
-    # Handle case where protocols don't exist yet
-    NavigatorProtocol = object
-    SensorProtocol = object
-    PROTOCOLS_AVAILABLE = False
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
+PROTOCOLS_AVAILABLE = True
 
 # Hydra integration for configuration management
 try:

--- a/src/plume_nav_sim/core/sensors/concentration_sensor.py
+++ b/src/plume_nav_sim/core/sensors/concentration_sensor.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 # Core protocol import
-from ..protocols import SensorProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Base sensor infrastructure
 try:

--- a/src/plume_nav_sim/core/sensors/gradient_sensor.py
+++ b/src/plume_nav_sim/core/sensors/gradient_sensor.py
@@ -59,7 +59,7 @@ from enum import Enum
 import numpy as np
 
 # Core protocol imports
-from ..protocols import SensorProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Enhanced logging for performance monitoring
 try:

--- a/src/plume_nav_sim/core/sensors/historical_sensor.py
+++ b/src/plume_nav_sim/core/sensors/historical_sensor.py
@@ -72,7 +72,7 @@ from collections import deque
 import numpy as np
 
 # Core protocol imports
-from ..protocols import SensorProtocol
+from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Hydra integration for configuration management
 try:
@@ -416,6 +416,16 @@ class HistoricalSensor:
         if not isinstance(base_sensor, SensorProtocol):
             raise TypeError(
                 f"base_sensor must implement SensorProtocol, got {type(base_sensor)}"
+            )
+
+        if LOGURU_AVAILABLE:
+            metadata = base_sensor.get_metadata() if hasattr(base_sensor, 'get_metadata') else {}
+            observation_shape = getattr(base_sensor, 'observation_shape', None)
+            logger.debug(
+                "Base sensor protocol compliance validated",
+                base_sensor_type=type(base_sensor).__name__,
+                observation_shape=observation_shape,
+                metadata=metadata
             )
         
         self.base_sensor = base_sensor

--- a/tests/core/test_sensor_logging.py
+++ b/tests/core/test_sensor_logging.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import MagicMock
+
+from src.plume_nav_sim.core import sensors as sensors_module
+from src.plume_nav_sim.core.sensors.binary_sensor import BinarySensor
+from src.plume_nav_sim.core.sensors import historical_sensor as hs
+from src.plume_nav_sim.core.sensors.historical_sensor import HistoricalSensorConfig
+
+
+def test_create_sensor_from_config_logs_protocol_validation(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(sensors_module, "logger", mock_logger)
+
+    sensors_module.create_sensor_from_config({"type": "BinarySensor"})
+
+    assert mock_logger.debug.called, "Expected debug log for protocol validation"
+    kwargs = mock_logger.debug.call_args.kwargs
+    assert "metadata" in kwargs
+    assert "observation_shape" in kwargs
+
+
+def test_historical_sensor_logs_base_sensor_validation(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(hs, "logger", mock_logger)
+
+    base_sensor = BinarySensor()
+    config = HistoricalSensorConfig(history_length=5)
+    hs.HistoricalSensor(base_sensor=base_sensor, config=config)
+
+    assert mock_logger.debug.called, "Expected debug log for base sensor validation"
+    kwargs = mock_logger.debug.call_args.kwargs
+    assert "metadata" in kwargs
+    assert "observation_shape" in kwargs


### PR DESCRIPTION
## Summary
- pull SensorProtocol from `plume_nav_sim.protocols.sensor` across controllers and sensors
- remove local protocol shims
- log sensor metadata and observation shape when adapters validate protocol compliance
- add tests for logging behavior

## Testing
- `pytest -q -o addopts="" tests/core/test_sensor_logging.py`
- `pytest -q -o addopts="" tests/core/test_sensors.py::TestSensorProtocolCompliance::test_binary_sensor_protocol_compliance`


------
https://chatgpt.com/codex/tasks/task_e_68afb02577148320952e94e0dc86b9bc