### PR TITLE
refactor: centralize plume model protocol and enforce contracts

### DIFF
--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -135,27 +135,10 @@ if TYPE_CHECKING:
     from ..core.protocols import NavigatorProtocol
     from ..envs.plume_navigation_env import PlumeNavigationEnv
 
+from plume_nav_sim.protocols.plume_model import PlumeModelProtocol
+
 
 # Enhanced Protocol Definitions for Modular Architecture
-
-class PlumeModelProtocol(Protocol):
-    """Protocol defining the interface for pluggable plume model implementations."""
-    
-    def concentration_at(self, positions: np.ndarray) -> np.ndarray:
-        """Sample odor concentration at specified positions."""
-        ...
-    
-    def step(self, dt: float) -> None:
-        """Advance plume state by time delta."""
-        ...
-    
-    def reset(self) -> None:
-        """Reset plume to initial state."""
-        ...
-    
-    def get_metadata(self) -> Dict[str, Any]:
-        """Get model-specific metadata and configuration."""
-        ...
 
 
 class WindFieldProtocol(Protocol):

--- a/tests/models/test_plume_protocol_compliance.py
+++ b/tests/models/test_plume_protocol_compliance.py
@@ -1,0 +1,49 @@
+import logging
+import pytest
+from plume_nav_sim.models.plume.gaussian_plume import GaussianPlumeModel, create_gaussian_plume_model
+from plume_nav_sim.models.plume import create_plume_model, AVAILABLE_PLUME_MODELS
+from plume_nav_sim.protocols.plume_model import PlumeModelProtocol
+
+
+def test_gaussian_plume_requires_contract_methods():
+    model = GaussianPlumeModel()
+    with pytest.raises(TypeError):
+        model.step()
+    with pytest.raises(TypeError):
+        model.reset("extra")
+    with pytest.raises(TypeError):
+        model.reset(source_position=(0.0, 0.0))
+
+
+def test_factory_logs_protocol_compliance(caplog):
+    with caplog.at_level(logging.DEBUG):
+        model = create_gaussian_plume_model({})
+    assert isinstance(model, PlumeModelProtocol)
+    assert "GaussianPlumeModel complies with PlumeModelProtocol" in caplog.text
+
+
+class _IncompletePlume:
+    def concentration_at(self, positions):
+        return [0.0]
+    def step(self, dt: float) -> None:
+        pass
+    # reset missing
+
+
+def test_create_plume_model_validates_protocol(monkeypatch, caplog):
+    dummy_info = {
+        'class': _IncompletePlume,
+        'config_class': None,
+        'factory_function': None,
+        'description': '',
+        'features': [],
+        'performance': {},
+        'use_cases': [],
+        'available': True,
+    }
+    monkeypatch.setitem(AVAILABLE_PLUME_MODELS, 'IncompletePlume', dummy_info)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(RuntimeError):
+            create_plume_model({'type': 'IncompletePlume'})
+    assert "IncompletePlume does not implement PlumeModelProtocol" in caplog.text
+    del AVAILABLE_PLUME_MODELS['IncompletePlume']


### PR DESCRIPTION
## Summary
- import `PlumeModelProtocol` from shared protocol module in plume models and simulation core
- align `concentration_at`, `step`, and `reset` signatures and simplify resets
- add debug logging in plume model factories verifying protocol compliance

## Testing
- `pytest tests/models/test_plume_protocol_compliance.py -q -o addopts=""`
- `pytest -q -o addopts=""` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*

------
https://chatgpt.com/codex/tasks/task_e_68afb0272b74832081ed03708d82e7a0