### PR TITLE
feat: add performance monitor protocol

### DIFF
--- a/src/plume_nav_sim/protocols/performance_monitor.py
+++ b/src/plume_nav_sim/protocols/performance_monitor.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Protocol, Dict, Any, runtime_checkable
+from typing import Protocol, Dict, runtime_checkable
 
 
 @runtime_checkable
 class PerformanceMonitorProtocol(Protocol):
     """Interface for collecting simulation performance metrics."""
 
-    def record_step(self, data: Dict[str, Any]) -> None:
+    def record_step(self, duration_ms: float, label: str | None = None) -> None:
         """Record metrics for a single simulation step."""
 
-    def record_episode(self, data: Dict[str, Any]) -> None:
-        """Record aggregated metrics for an episode."""
-
-    def get_metrics(self) -> Dict[str, float]:
+    def export(self) -> Dict[str, float]:
         """Return accumulated performance statistics."""
 
 

--- a/tests/protocols/test_performance_monitor_adapter.py
+++ b/tests/protocols/test_performance_monitor_adapter.py
@@ -1,0 +1,20 @@
+import logging
+
+import pytest
+
+from plume_nav_sim.core.simulation import PerformanceMonitor
+
+
+def test_record_step_logs_and_exports(caplog):
+    monitor = PerformanceMonitor()
+    with caplog.at_level(logging.INFO):
+        monitor.record_step(5.0, label="step")
+    assert "step" in caplog.text
+    exported = monitor.export()
+    assert exported["step"] == pytest.approx(5.0)
+
+
+def test_record_step_invalid_duration():
+    monitor = PerformanceMonitor()
+    with pytest.raises(ValueError):
+        monitor.record_step(-1.0, label="bad")

--- a/tests/protocols/test_simulation_protocols.py
+++ b/tests/protocols/test_simulation_protocols.py
@@ -42,11 +42,10 @@ PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
     },
     "PerformanceMonitorProtocol": {
         "methods": {
-            "record_step": lambda self, data: None,
-            "record_episode": lambda self, data: None,
-            "get_metrics": lambda self: {"dummy": 0.0},
+            "record_step": lambda self, duration_ms, label=None: None,
+            "export": lambda self: {"dummy": 0.0},
         },
-        "missing": "record_episode",
+        "missing": "export",
     },
 }
 


### PR DESCRIPTION
## Summary
- add record_step and export to performance monitor protocol
- implement basic PerformanceMonitor that logs durations and validates inputs
- record step and hook timings in simulation via protocol

## Testing
- `python -m pytest -o addopts='' tests/protocols/test_simulation_protocols.py tests/protocols/test_performance_monitor_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb02b4fb48320802b3d63d349ed02