### PR TITLE
feat(protocols): use action arrays for navigator step

### DIFF
--- a/src/plume_nav_sim/protocols/navigator.py
+++ b/src/plume_nav_sim/protocols/navigator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Protocol, Dict, Any, runtime_checkable
+import numpy as np
 
 
 @runtime_checkable
@@ -17,8 +18,8 @@ class NavigatorProtocol(Protocol):
     def reset(self) -> None:
         """Reset the navigator to its initial state."""
 
-    def step(self, dt: float) -> None:
-        """Advance the navigator state by ``dt`` seconds."""
+    def step(self, action: np.ndarray) -> None:
+        """Advance the navigator state using the provided action array."""
 
     def get_state(self) -> Dict[str, Any]:
         """Return a snapshot of the navigator's current state."""

--- a/tests/protocols/test_simulation_protocols.py
+++ b/tests/protocols/test_simulation_protocols.py
@@ -12,7 +12,7 @@ PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
     "NavigatorProtocol": {
         "methods": {
             "reset": lambda self: None,
-            "step": lambda self, dt: None,
+            "step": lambda self, action: None,
             "get_state": lambda self: {},
         },
         "missing": "step",

--- a/tests/test_protocol_refactor.py
+++ b/tests/test_protocol_refactor.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+import inspect
+from typing import get_type_hints
 
 from plume_nav_sim.api.navigation import from_legacy
 from plume_nav_sim.core import protocols as core_protocols
@@ -8,6 +10,15 @@ from plume_nav_sim.protocols import navigator as navigator_mod
 
 def test_core_protocols_navigator_protocol_is_global():
     assert core_protocols.NavigatorProtocol is navigator_mod.NavigatorProtocol
+
+
+def test_navigator_protocol_step_signature():
+    sig = inspect.signature(navigator_mod.NavigatorProtocol.step)
+    params = list(sig.parameters.values())
+    assert len(params) == 2
+    assert params[1].name == "action"
+    hints = get_type_hints(navigator_mod.NavigatorProtocol.step)
+    assert hints["action"] is np.ndarray
 
 
 class MissingStepNavigator:


### PR DESCRIPTION
## Summary
- require NavigatorProtocol.step to accept an action array instead of dt
- update protocol test specifications
- add regression test ensuring new step signature

## Testing
- `pytest tests/test_protocol_refactor.py tests/protocols/test_simulation_protocols.py::test_protocol_structural_compatibility -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68afb589dc3c8320a7818322af7d816d