### PR TITLE
feat: extend sensor protocol with gradient and configuration hooks

### DIFF
--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -87,6 +87,7 @@ import warnings
 import inspect
 from typing import Dict, Tuple, Optional, Any, Union, List, SupportsFloat, Literal
 from pathlib import Path
+import logging
 import numpy as np
 
 # Gymnasium imports with fallback compatibility
@@ -360,7 +361,7 @@ except ImportError:
             return concentration_values >= self.threshold
         
         def configure(self, **kwargs):
-            pass
+            logging.getLogger(__name__).debug("BinarySensor configured with %s", kwargs)
         
         def get_metadata(self):
             return {"type": "binary", "threshold": self.threshold}
@@ -376,7 +377,7 @@ except ImportError:
             return np.clip(concentration_values, *self.dynamic_range)
         
         def configure(self, **kwargs):
-            pass
+            logging.getLogger(__name__).debug("ConcentrationSensor configured with %s", kwargs)
         
         def get_metadata(self):
             return {"type": "concentration", "range": self.dynamic_range}
@@ -389,12 +390,14 @@ except ImportError:
             self.spatial_resolution = spatial_resolution
         
         def compute_gradient(self, plume_state: Any, positions: np.ndarray, **kwargs) -> np.ndarray:
+            logger = logging.getLogger(__name__)
+            logger.debug("GradientSensor computing gradient for %d positions", len(positions))
             if positions.ndim == 1:
                 return np.random.rand(2) - 0.5  # Random gradient direction
             return np.random.rand(len(positions), 2) - 0.5
         
         def configure(self, **kwargs):
-            pass
+            logging.getLogger(__name__).debug("GradientSensor configured with %s", kwargs)
         
         def get_metadata(self):
             return {"type": "gradient", "resolution": self.spatial_resolution}

--- a/src/plume_nav_sim/protocols/sensor.py
+++ b/src/plume_nav_sim/protocols/sensor.py
@@ -19,5 +19,36 @@ class SensorProtocol(Protocol):
     def measure(self, plume_state: Any, positions: Sequence[Sequence[float]]) -> Sequence[float]:
         """Return scalar measurements for agents at ``positions``."""
 
+    def compute_gradient(
+        self, plume_state: Any, positions: Sequence[Sequence[float]]
+    ) -> Sequence[Sequence[float]]:
+        """Estimate spatial concentration gradients at agent positions.
+
+        Args:
+            plume_state: Arbitrary plume model state used to compute gradients.
+            positions: Collection of agent coordinates for sampling the field.
+
+        Returns:
+            A sequence of 2-D gradient vectors aligned with ``positions``. Each
+            vector represents the concentration change along the x and y axes
+            at the corresponding agent position.
+
+        Notes:
+            Implementations should raise a descriptive error if gradient
+            computation is unsupported for the provided ``plume_state`` or if
+            the ``positions`` input is malformed.
+        """
+
+    def configure(self, **kwargs: Any) -> None:
+        """Update internal sensor parameters at runtime.
+
+        Implementations may support a variety of configuration options such as
+        detection thresholds, dynamic ranges, or spatial resolution. Unknown
+        parameters should raise a ``TypeError`` to avoid silent failures.
+
+        Args:
+            **kwargs: Implementation-specific keyword arguments.
+        """
+
 
 __all__ = ["SensorProtocol"]

--- a/tests/protocols/test_simulation_protocols.py
+++ b/tests/protocols/test_simulation_protocols.py
@@ -21,8 +21,10 @@ PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
         "methods": {
             "detect": lambda self, plume_state, positions: [False],
             "measure": lambda self, plume_state, positions: [0.0],
+            "compute_gradient": lambda self, plume_state, positions: [(0.0, 0.0)],
+            "configure": lambda self, **kwargs: None,
         },
-        "missing": "measure",
+        "missing": "compute_gradient",
     },
     "PlumeModelProtocol": {
         "methods": {


### PR DESCRIPTION
## Summary
- add `compute_gradient` and `configure` to `SensorProtocol`
- expand simulation protocol tests for gradient and configuration methods
- log sensor configuration and gradient computations in adapter helpers

## Testing
- `pytest tests/protocols/test_simulation_protocols.py -o addopts='' -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68afbe731bf88320b6e02aebdf0f1ea3