### PR TITLE
feat(core): instantiate components via registry

### DIFF
--- a/tests/core/test_simulation_context_factory.py
+++ b/tests/core/test_simulation_context_factory.py
@@ -1,0 +1,20 @@
+import pytest
+
+from plume_nav_sim.core.simulation import SimulationContext
+from plume_nav_sim.protocols.plume_model import PlumeModelProtocol
+from plume_nav_sim.protocols.wind_field import WindFieldProtocol
+
+
+class TestSimulationContextFactory:
+    def test_add_plume_model_instantiates_real_model(self):
+        ctx = SimulationContext.create()
+        ctx.add_plume_model("GaussianPlumeModel")
+        component = next(iter(ctx.components.values()))
+        plume = component["instance"]
+        assert isinstance(plume, PlumeModelProtocol)
+        assert type(plume).__name__ == "GaussianPlumeModel"
+
+    def test_add_wind_field_invalid_type_raises(self):
+        ctx = SimulationContext.create()
+        with pytest.raises(Exception):
+            ctx.add_wind_field("NonexistentWindField")


### PR DESCRIPTION
## Summary
- use registry-based factories to create plume models, wind fields, and sensors in `SimulationContext`
- add unit tests for `SimulationContext` factory methods

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/core/test_simulation_context_factory.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b032c682e4832089e03b474b366781