### PR TITLE
feat(core): instantiate components via registry

### DIFF
--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -67,11 +67,15 @@ import time
 import contextlib
 import warnings
 from typing import Optional, Tuple, Dict, Any, Union, List, Protocol, TYPE_CHECKING
-from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 import numpy as np
 from dataclasses import dataclass, field
 import logging
 
+from .protocols import (
+    PlumeModelProtocol,
+    WindFieldProtocol,
+    SensorProtocol,
+)
 from ..protocols import PerformanceMonitorProtocol
 from pathlib import Path
 
@@ -136,29 +140,11 @@ except ImportError:
 
 # Type checking imports
 if TYPE_CHECKING:
-    from plume_nav_sim.protocols.navigator import NavigatorProtocol
+    from .protocols import NavigatorProtocol
     from ..envs.plume_navigation_env import PlumeNavigationEnv
-
-from plume_nav_sim.protocols.plume_model import PlumeModelProtocol
 
 
 # Enhanced Protocol Definitions for Modular Architecture
-
-
-class SensorProtocol(Protocol):
-    """Protocol defining the interface for sensor implementations."""
-    
-    def sense(self, plume_state: Any, positions: np.ndarray) -> np.ndarray:
-        """Process sensor readings at specified positions."""
-        ...
-    
-    def get_observation_space_info(self) -> Dict[str, Any]:
-        """Get information for observation space construction."""
-        ...
-    
-    def get_metadata(self) -> Dict[str, Any]:
-        """Get sensor-specific metadata and configuration."""
-        ...
 
 
 class ComponentMetrics(Protocol):
@@ -1130,97 +1116,87 @@ class SimulationContext:
     
     def add_plume_model(self, model_type: str, **kwargs: Any) -> 'SimulationContext':
         """Add plume model component with configuration."""
-        # In full implementation, this would use a component factory
-        # to instantiate the appropriate plume model based on model_type
         plume_model = self._create_plume_model(model_type, **kwargs)
         return self.add_component("plume_model", plume_model)
     
     def add_wind_field(self, field_type: str, **kwargs: Any) -> 'SimulationContext':
         """Add wind field component with configuration."""
-        # In full implementation, this would use a component factory
         wind_field = self._create_wind_field(field_type, **kwargs)
         return self.add_component("wind_field", wind_field)
     
     def add_sensor(self, sensor_type: str, **kwargs: Any) -> 'SimulationContext':
         """Add sensor component with configuration."""
-        # In full implementation, this would use a component factory
         sensor = self._create_sensor(sensor_type, **kwargs)
         return self.add_component("sensor", sensor)
     
     def _create_plume_model(self, model_type: str, **kwargs: Any) -> PlumeModelProtocol:
         """Factory method for creating plume model instances."""
-        # Placeholder implementation - would be replaced with actual component factory
-        class MockPlumeModel:
-            def __init__(self, model_type: str, **kwargs):
-                self.model_type = model_type
-                self.config = kwargs
-                
-            def concentration_at(self, positions: np.ndarray) -> np.ndarray:
-                return np.random.random(len(positions))
-                
-            def step(self, dt: float) -> None:
-                pass
-                
-            def reset(self) -> None:
-                pass
-                
-            def get_metadata(self) -> Dict[str, Any]:
-                return {"type": self.model_type, "config": self.config}
-        
-        return MockPlumeModel(model_type, **kwargs)
+        from plume_nav_sim.models import create_plume_model
+
+        config = {"type": model_type, **kwargs}
+        logger.info(
+            "Creating plume model",
+            extra={"model_type": model_type, "config_keys": list(kwargs.keys())},
+        )
+        plume_model = create_plume_model(config)
+
+        if not isinstance(plume_model, PlumeModelProtocol):
+            logger.error(
+                "Created plume model does not implement PlumeModelProtocol",
+                extra={"model_type": model_type},
+            )
+            raise TypeError(
+                f"Plume model {model_type} is not protocol compliant"
+            )
+
+        return plume_model
     
     def _create_wind_field(self, field_type: str, **kwargs: Any) -> WindFieldProtocol:
         """Factory method for creating wind field instances."""
-        # Placeholder implementation - would be replaced with actual component factory
-        class MockWindField:
-            def __init__(self, field_type: str, **kwargs):
-                self.field_type = field_type
-                self.config = kwargs
+        from plume_nav_sim.models import create_wind_field
 
-            def velocity_at(self, positions: np.ndarray, time: float) -> np.ndarray:
-                return np.random.random((len(positions), 2))
+        config = {"type": field_type, **kwargs}
+        logger.info(
+            "Creating wind field",
+            extra={"field_type": field_type, "config_keys": list(kwargs.keys())},
+        )
+        wind_field = create_wind_field(config)
 
-            def step(self, dt: float) -> None:
-                pass
-
-            def reset(self) -> None:
-                pass
-
-            def get_metadata(self) -> Dict[str, Any]:
-                return {"type": self.field_type, "config": self.config}
-
-        wind_field = MockWindField(field_type, **kwargs)
-        missing = [
-            m for m in ("velocity_at", "step", "reset")
-            if not callable(getattr(wind_field, m, None))
-        ]
-        if missing:
+        if not isinstance(wind_field, WindFieldProtocol):
             logger.error(
-                f"Wind field missing required methods: {', '.join(missing)}"
+                "Created wind field does not implement WindFieldProtocol",
+                extra={"field_type": field_type},
             )
-            raise RuntimeError(
-                f"Instantiated wind field missing required methods: {', '.join(missing)}"
+            raise TypeError(
+                f"Wind field {field_type} is not protocol compliant"
             )
+
         return wind_field
     
     def _create_sensor(self, sensor_type: str, **kwargs: Any) -> SensorProtocol:
         """Factory method for creating sensor instances."""
-        # Placeholder implementation - would be replaced with actual component factory
-        class MockSensor:
-            def __init__(self, sensor_type: str, **kwargs):
-                self.sensor_type = sensor_type
-                self.config = kwargs
-                
-            def sense(self, plume_state: Any, positions: np.ndarray) -> np.ndarray:
-                return np.random.random(len(positions))
-                
-            def get_observation_space_info(self) -> Dict[str, Any]:
-                return {"shape": (1,), "dtype": "float32"}
-                
-            def get_metadata(self) -> Dict[str, Any]:
-                return {"type": self.sensor_type, "config": self.config}
-        
-        return MockSensor(sensor_type, **kwargs)
+        from plume_nav_sim.models import create_sensors
+
+        config = {"type": sensor_type, **kwargs}
+        logger.info(
+            "Creating sensor",
+            extra={"sensor_type": sensor_type, "config_keys": list(kwargs.keys())},
+        )
+        sensors = create_sensors([config])
+        if not sensors:
+            raise ValueError(f"Sensor factory returned no instance for {sensor_type}")
+        sensor = sensors[0]
+
+        if not isinstance(sensor, SensorProtocol):
+            logger.error(
+                "Created sensor does not implement SensorProtocol",
+                extra={"sensor_type": sensor_type},
+            )
+            raise TypeError(
+                f"Sensor {sensor_type} is not protocol compliant"
+            )
+
+        return sensor
     
     def __enter__(self) -> 'SimulationContext':
         """Enter context manager and initialize all components."""

--- a/tests/core/test_simulation_context_factory.py
+++ b/tests/core/test_simulation_context_factory.py
@@ -1,0 +1,31 @@
+import pytest
+
+from plume_nav_sim.core.simulation import SimulationContext
+from plume_nav_sim.core.protocols import (
+    PlumeModelProtocol,
+    WindFieldProtocol,
+    SensorProtocol,
+)
+
+
+class TestSimulationContextFactory:
+    def test_add_plume_model_instantiates_real_model(self):
+        ctx = SimulationContext.create()
+        ctx.add_plume_model("GaussianPlumeModel")
+        component = next(iter(ctx.components.values()))
+        plume = component["instance"]
+        assert isinstance(plume, PlumeModelProtocol)
+        assert type(plume).__name__ == "GaussianPlumeModel"
+
+    def test_add_wind_field_invalid_type_raises(self):
+        ctx = SimulationContext.create()
+        with pytest.raises(Exception):
+            ctx.add_wind_field("NonexistentWindField")
+
+    def test_add_sensor_instantiates_real_sensor(self):
+        ctx = SimulationContext.create()
+        ctx.add_sensor("BinarySensor", threshold=0.1)
+        component = next(iter(ctx.components.values()))
+        sensor = component["instance"]
+        assert isinstance(sensor, SensorProtocol)
+        assert type(sensor).__name__ == "BinarySensor"


### PR DESCRIPTION
## Summary
- use centralized protocol imports in `SimulationContext`
- validate sensors against protocol and add sensor factory test

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/core/test_simulation_context_factory.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b032c682e4832089e03b474b366781