### PR TITLE
refactor: remove legacy navigation fallbacks

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -251,6 +251,14 @@ class TestNavigatorCreation:
         with pytest.raises(ValueError, match=r"Cannot specify both 'position' \(single-agent\) and 'positions' \(multi-agent\). Please provide only one."):
             create_navigator(position=(0, 0), positions=[(1, 2), (3, 4)])
 
+    def test_create_navigator_unavailable(self, monkeypatch):
+        """Navigator creation should fail when core Navigator is unavailable."""
+        import plume_nav_sim.api.navigation as nav
+
+        monkeypatch.setattr(nav, "Navigator", None)
+        with pytest.raises(ImportError):
+            nav.create_navigator()
+
 
 class TestHydraConfigurationIntegration:
     """Test suite for Hydra configuration integration with enhanced pytest-hydra support."""
@@ -781,6 +789,11 @@ class TestSimulationExecution:
             assert result_positions.shape == (2, 2, 2)
             assert result_orientations.shape == (2, 2)
             assert result_readings.shape == (2, 2)
+
+    def test_run_plume_simulation_not_implemented(self, sample_navigator, sample_video_plume):
+        """Simulation entry point should raise when implementation missing."""
+        with pytest.raises(NotImplementedError):
+            run_plume_simulation(sample_navigator, sample_video_plume, num_steps=1, dt=1.0)
 
 
 class TestVisualizationIntegration:


### PR DESCRIPTION
## Summary
- remove placeholder navigator logic and require core Navigator
- deprecate run_plume_simulation stub and visualization fallback
- drop CLI environment fallbacks and schema placeholders

## Testing
- `pytest tests/api/test_api.py::TestNavigatorCreation::test_create_navigator_unavailable tests/api/test_api.py::TestSimulationExecution::test_run_plume_simulation_not_implemented -q --override-ini="addopts="`
- `pytest tests/api/test_api.py::TestSimulationExecution -q --override-ini="addopts="`
- `pytest tests/api/test_api_surface.py -q --override-ini="addopts="`
- `pytest tests/test_cli_main.py -q --override-ini="addopts="` *(fails: ImportError: cannot import name 'close_session')*

------
https://chatgpt.com/codex/tasks/task_e_68b0330e1e188320889d054a96aa5db1