### PR TITLE
fix: normalize video plume configuration handling

### DIFF
--- a/src/odor_plume_nav/config/models.py
+++ b/src/odor_plume_nav/config/models.py
@@ -400,15 +400,17 @@ class _VideoPlumeConfigModel(BaseModel):
     # --------------------------------------------------------------------- #
     @model_validator(mode='after')
     def _validate_gaussian_and_frames(cls, values):
-        if values.get("_skip_validation"):
-            # Skip heavy validation when requested (e.g., file existence)
+        # ``values`` is the model instance in Pydantic v2; use attribute access
+        if getattr(values, "_skip_validation", False):
             return values
 
-        kernel_size, kernel_sigma = values.get("kernel_size"), values.get("kernel_sigma")
+        kernel_size = getattr(values, "kernel_size")
+        kernel_sigma = getattr(values, "kernel_sigma")
         if (kernel_size is not None) != (kernel_sigma is not None):
             raise ValueError("Both kernel_size and kernel_sigma must be specified together")
 
-        sf, ef = values.get("start_frame"), values.get("end_frame")
+        sf = getattr(values, "start_frame")
+        ef = getattr(values, "end_frame")
         if sf is not None and ef is not None and ef <= sf:
             raise ValueError("end_frame must be greater than start_frame")
         return values

--- a/src/odor_plume_nav/data/video_plume.py
+++ b/src/odor_plume_nav/data/video_plume.py
@@ -169,7 +169,7 @@ class VideoPlume:
         # Convert and validate video path
         self.video_path = Path(video_path)
         if not self.video_path.exists():
-            raise FileNotFoundError(f"Video file does not exist: {self.video_path}")
+            raise FileNotFoundError(f"Video file not found: {self.video_path}")
         
         # Store preprocessing parameters
         self.flip = flip
@@ -893,7 +893,7 @@ class VideoPlume:
             "file_size": self.video_path.stat().st_size,
             "workflow_version": "1.0",
             "dependencies": {
-                "opencv_version": cv2.__version__,
+                "opencv_version": getattr(cv2, "__version__", "unknown"),
                 "numpy_version": np.__version__,
             }
         }


### PR DESCRIPTION
## Summary
- raise clear FileNotFoundError when video path missing
- normalize dict-like configs and handle Pydantic models
- adjust schema validation for Pydantic v2 compatibility

## Testing
- `pytest -q -o addopts='' tests/environments/test_video_plume.py tests/models/test_plume_models.py tests/test_video_plume_factory.py` *(fails: AttributeError, regex mismatch)*
- `pytest -q -o addopts='' tests/environments/test_video_plume.py::test_configuration_format_validation -k ''`

------
https://chatgpt.com/codex/tasks/task_e_68b0f3ad36148320926cec6f0f494e10