### PR TITLE
fix: handle one-dimensional wind velocities in plume model

### DIFF
--- a/src/plume_nav_sim/models/plume/gaussian_plume.py
+++ b/src/plume_nav_sim/models/plume/gaussian_plume.py
@@ -460,12 +460,18 @@ class GaussianPlumeModel:
         if self.enable_wind_field and self.wind_field is not None:
             # Use wind field for complex dynamics
             source_pos = np.atleast_2d(self.source_position)
-            wind_velocity = self.wind_field.velocity_at(source_pos)[0]
+            wind_velocity = self.wind_field.velocity_at(source_pos)
+            wind_velocity = np.asarray(wind_velocity, dtype=np.float64)
+            wind_velocity = np.atleast_2d(wind_velocity)[0]
+            if wind_velocity.shape[0] != 2:
+                raise ValueError(
+                    f"Wind field velocity_at must return 2 components, got shape {wind_velocity.shape}"
+                )
             advection_offset = wind_velocity * self.current_time
         else:
             # Use simple wind model
             advection_offset = self.wind_velocity * self.current_time
-        
+
         return self.source_position + advection_offset
     
     def _compute_concentrations_scipy(self, dx: np.ndarray, dy: np.ndarray) -> np.ndarray:

--- a/tests/models/test_plume_models.py
+++ b/tests/models/test_plume_models.py
@@ -889,6 +889,32 @@ class TestGaussianPlumeModelMathematicalValidation:
         assert isinstance(final_concentration, (float, np.number)), \
             "Wind integration should produce valid concentration"
 
+    def test_gaussian_wind_field_handles_1d_velocity(self, gaussian_plume_config):
+        """Wind field returning 1D velocity should shift plume correctly."""
+
+        class OneDimensionalWind:
+            def __init__(self, velocity):
+                self.velocity = np.asarray(velocity, dtype=float)
+
+            def velocity_at(self, positions):
+                return self.velocity  # intentionally 1D
+
+            def step(self, dt):
+                pass
+
+            def reset(self):
+                pass
+
+        wind = OneDimensionalWind((1.0, -0.5))
+        config = gaussian_plume_config.copy()
+        config.update({'wind_field': wind, 'enable_wind_field': True})
+
+        model = GaussianPlumeModel(**config)
+        model.current_time = 2.0
+
+        expected = np.array(config['source_position']) + np.array([1.0, -0.5]) * 2.0
+        assert np.allclose(model._get_effective_source_position(), expected)
+
 
 # =====================================================================================
 # TURBULENT PLUME MODEL FILAMENT-BASED PHYSICS VALIDATION TESTS


### PR DESCRIPTION
## Summary
- make GaussianPlumeModel robust to wind fields returning 1D velocity arrays
- test wind-driven advection when wind fields yield 1D velocity vectors

## Testing
- `pytest -q --override-ini="addopts=" tests/models/test_plume_models.py tests/models/test_wind_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f47f0e4c83208ef1f4385b1f0084