### PR TITLE
refactor: migrate DirectOdorSensor to SensorProtocol

### DIFF
--- a/tests/core/test_sensors.py
+++ b/tests/core/test_sensors.py
@@ -55,6 +55,7 @@ try:
     from src.plume_nav_sim.core.sensors.binary_sensor import BinarySensor, BinarySensorConfig
     from src.plume_nav_sim.core.sensors.concentration_sensor import ConcentrationSensor, ConcentrationSensorConfig
     from src.plume_nav_sim.core.sensors.gradient_sensor import GradientSensor, GradientSensorConfig, GradientResult
+    from src.plume_nav_sim.core.controllers import DirectOdorSensor
     SENSORS_AVAILABLE = True
 except ImportError as e:
     pytest.skip(f"Sensor implementations not available: {e}", allow_module_level=True)
@@ -146,6 +147,15 @@ def concentration_array():
     center_x, center_y = 50, 50
     concentration = np.exp(-((x - center_x)**2 + (y - center_y)**2) / (2 * 15**2))
     return concentration.astype(np.float64)
+
+
+def test_direct_odor_sensor_interface():
+    """DirectOdorSensor should expose modern sensing interface."""
+    sensor = DirectOdorSensor()
+
+    assert hasattr(sensor, "detect") and callable(sensor.detect)
+    assert hasattr(sensor, "measure") and callable(sensor.measure)
+    assert hasattr(sensor, "compute_gradient") and callable(sensor.compute_gradient)
 
 
 class TestSensorProtocolCompliance:


### PR DESCRIPTION
## Summary
- add regression test for DirectOdorSensor interface
- refactor DirectOdorSensor to implement detect/measure/compute_gradient with debug logs
- replace legacy `sample` usage with new methods and raise explicit exceptions

## Testing
- `pytest tests/core/test_sensors.py::test_direct_odor_sensor_interface -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fccbe0e0832094972d6f24da83fe