### PR TITLE
fix(navigator): raise ImportError when controllers are missing

### DIFF
--- a/tests/core/test_navigator.py
+++ b/tests/core/test_navigator.py
@@ -166,6 +166,30 @@ except ImportError:
     ConfigStore = None
 
 
+def test_import_navigator_without_controllers_raises(monkeypatch):
+    """Navigator should raise ImportError when controllers are unavailable."""
+    import sys
+    import builtins
+
+    # Ensure fresh import of navigator and controllers
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.core.navigator", raising=False)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.core.controllers", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "plume_nav_sim.core.controllers" or (
+            level == 1 and name == "controllers"
+        ):
+            raise ImportError("controllers missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        __import__("plume_nav_sim.core.navigator")
+
+
 # Enhanced test fixtures for Gymnasium 0.29.x API compliance and structured configuration testing
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- ensure Navigator import fails when controllers module is absent
- clean up controller import logic and remove fallbacks
- add regression test for missing controllers

## Testing
- `pytest tests/core/test_navigator.py -k without_controllers -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2017298288320b3834a77f064f1c9