### PR TITLE
feat: forward controller boundary policy and source

### DIFF
--- a/src/plume_nav_sim/core/navigator.py
+++ b/src/plume_nav_sim/core/navigator.py
@@ -306,6 +306,16 @@ class Navigator:
     def num_agents(self) -> int:
         """Get the total number of agents managed by this navigator."""
         return self.controller.num_agents
+
+    @property
+    def boundary_policy(self):
+        """Expose boundary policy from the underlying controller."""
+        return self.controller.boundary_policy
+
+    @property
+    def source(self):
+        """Expose odor source from the underlying controller."""
+        return self.controller.source
     
     def reset(self, **kwargs: Any) -> None:
         """
@@ -889,6 +899,8 @@ class Navigator:
             # If we can't parse it, let the controller handle the error
             return True
 
+
+NavigatorProtocol.register(Navigator)
 
 class NavigatorFactory(BaseNavigatorFactory):
     """

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -13,7 +13,7 @@ from typing import Dict, Any
 import warnings
 
 # Import new navigator structure
-from plume_nav_sim.core.navigator import NavigatorProtocol
+from plume_nav_sim.core.navigator import Navigator, NavigatorProtocol
 from plume_nav_sim.core.controllers import SingleAgentController, MultiAgentController
 from plume_nav_sim.api.navigation import (
     create_navigator,
@@ -230,6 +230,23 @@ class TestNavigatorProtocolCompliance:
     def test_navigator_runtime_protocol_check(self, navigator):
         """Test runtime protocol compliance checking."""
         assert isinstance(navigator, NavigatorProtocol)
+
+
+class TestNavigatorControllerSync:
+    """Test that Navigator forwards controller dependency properties."""
+
+    def test_boundary_policy_and_source_forwarding(self):
+        """Navigator properties should reflect controller dependencies."""
+        boundary = MagicMock(name="boundary")
+        source = MagicMock(name="source")
+        controller = SingleAgentController(position=(0.0, 0.0))
+        controller._boundary_policy = boundary
+        controller._source = source
+
+        navigator = Navigator(controller=controller)
+
+        assert navigator.boundary_policy is boundary
+        assert navigator.source is source
 
 
 class TestNavigatorMovement:


### PR DESCRIPTION
## Summary
- expose controller boundary_policy and source through Navigator
- register Navigator with NavigatorProtocol
- add tests ensuring property forwarding

## Testing
- `pytest tests/test_navigator.py::TestNavigatorControllerSync::test_boundary_policy_and_source_forwarding tests/test_navigator.py::TestNavigatorProtocolCompliance::test_navigator_runtime_protocol_check -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2026f8da48320b769c187b3e330ea