### PR TITLE
feat: log controller hook invocations

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -1545,6 +1545,24 @@ class SingleAgentController(BaseController):
             # Return safe default values
             return np.zeros(num_sensors)
 
+    def compute_additional_obs(self, base_obs: dict) -> dict:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.compute_additional_obs invoked")
+        return super().compute_additional_obs(base_obs)
+
+    def compute_extra_reward(self, base_reward: float, info: dict) -> float:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.compute_extra_reward invoked")
+        return super().compute_extra_reward(base_reward, info)
+
+    def on_episode_end(self, final_info: dict) -> None:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.on_episode_end invoked")
+        super().on_episode_end(final_info)
+
 
 class MultiAgentController(BaseController):
     """
@@ -1768,7 +1786,25 @@ class MultiAgentController(BaseController):
     def num_agents(self) -> int:
         """Get the number of agents."""
         return self._positions.shape[0]
-    
+
+    def compute_additional_obs(self, base_obs: dict) -> dict:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.compute_additional_obs invoked")
+        return super().compute_additional_obs(base_obs)
+
+    def compute_extra_reward(self, base_reward: float, info: dict) -> float:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.compute_extra_reward invoked")
+        return super().compute_extra_reward(base_reward, info)
+
+    def on_episode_end(self, final_info: dict) -> None:
+        """Log hook invocation then delegate to base implementation."""
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__}.on_episode_end invoked")
+        super().on_episode_end(final_info)
+
     # NavigatorProtocol method implementations
     
     def reset(self, **kwargs: Any) -> None:

--- a/tests/core/test_controller_hooks.py
+++ b/tests/core/test_controller_hooks.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import MagicMock
+
+from src.plume_nav_sim.core.controllers import SingleAgentController, MultiAgentController
+
+
+class TestControllerHookDiscovery:
+    def test_single_agent_controller_hooks(self):
+        controller = SingleAgentController(enable_logging=True, enable_extensibility_hooks=True)
+        # Ensure hooks exist
+        assert hasattr(controller, "compute_additional_obs")
+        assert hasattr(controller, "compute_extra_reward")
+        assert hasattr(controller, "on_episode_end")
+
+        controller._logger = MagicMock()
+        controller.compute_additional_obs({})
+        controller.compute_extra_reward(0.0, {})
+        controller.on_episode_end({})
+
+        debug_calls = [c.args[0] for c in controller._logger.debug.call_args_list]
+        assert any("compute_additional_obs" in msg for msg in debug_calls)
+        assert any("compute_extra_reward" in msg for msg in debug_calls)
+        assert any("on_episode_end" in msg for msg in debug_calls)
+
+    def test_multi_agent_controller_hooks(self):
+        controller = MultiAgentController(enable_logging=True, enable_extensibility_hooks=True)
+        # Ensure hooks exist
+        assert hasattr(controller, "compute_additional_obs")
+        assert hasattr(controller, "compute_extra_reward")
+        assert hasattr(controller, "on_episode_end")
+
+        controller._logger = MagicMock()
+        controller.compute_additional_obs({})
+        controller.compute_extra_reward(0.0, {})
+        controller.on_episode_end({})
+
+        debug_calls = [c.args[0] for c in controller._logger.debug.call_args_list]
+        assert any("compute_additional_obs" in msg for msg in debug_calls)
+        assert any("compute_extra_reward" in msg for msg in debug_calls)
+        assert any("on_episode_end" in msg for msg in debug_calls)


### PR DESCRIPTION
## Summary
- log hook invocation in SingleAgentController and MultiAgentController
- add tests asserting controller hooks are discoverable and logged

## Testing
- `pytest tests/core/test_controller_hooks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b202716700832086929a507b8b7a06