### PR TITLE
feat(core): allow controllers to accept optional source

### DIFF
--- a/tests/core/test_controller_source.py
+++ b/tests/core/test_controller_source.py
@@ -1,0 +1,16 @@
+import pytest
+from unittest.mock import MagicMock
+from plume_nav_sim.core.controllers import SingleAgentController
+from plume_nav_sim.core.protocols import SourceProtocol
+
+
+def test_controller_accepts_source():
+    mock_source = MagicMock(spec=SourceProtocol)
+    controller = SingleAgentController(source=mock_source)
+    assert controller.source is mock_source
+
+
+def test_sampling_without_source_or_plume_state_raises():
+    controller = SingleAgentController()
+    with pytest.raises(ValueError):
+        controller.sample_odor(None)


### PR DESCRIPTION
## Summary
- allow BaseController to accept a SourceProtocol and warn when missing
- validate that odor sampling requires a plume state or source
- add tests covering source injection and missing plume state errors

## Testing
- `pytest tests/core/test_controller_source.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20277384c8320b7de5651c2074e5c