### PR TITLE
feat: handle scalar io for core sensors

### DIFF
--- a/src/plume_nav_sim/core/sensors/concentration_sensor.py
+++ b/src/plume_nav_sim/core/sensors/concentration_sensor.py
@@ -584,8 +584,9 @@ class ConcentrationSensor(BaseSensor):
                         performance_degradation=True
                     )
             
-            # Always return array for consistent API with vectorized operations
-            return measured_concentrations
+            if measured_concentrations.shape[0] == 1:
+                return np.float64(measured_concentrations[0])
+            return measured_concentrations.astype(np.float64)
                 
         except Exception as e:
             if self._enable_logging and LOGURU_AVAILABLE:


### PR DESCRIPTION
## Summary
- support scalar inputs in `BinarySensor.detect`
- return float64 scalar for single-agent `ConcentrationSensor.measure`
- test scalar I/O paths for binary and concentration sensors

## Testing
- `pytest tests/core/test_sensors.py::TestSensorFunctionality::test_binary_sensor_scalar_detection tests/core/test_sensors.py::TestSensorFunctionality::test_concentration_sensor_scalar_dtype tests/core/test_sensors.py::TestSensorFunctionality::test_concentration_sensor_quantitative_measurement -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a52ce9cc8320b4ec74e26b72eddb