### PR TITLE
fix(cli,config): align validation and export behavior

### DIFF
--- a/src/plume_nav_sim/cli/main.py
+++ b/src/plume_nav_sim/cli/main.py
@@ -665,7 +665,8 @@ def run(ctx, dry_run: bool, seed: Optional[int], output_dir: Optional[str],
 
     try:
         _validate_hydra_availability()
-        cfg = HydraConfig.get().cfg if HYDRA_AVAILABLE and HydraConfig.initialized() else None
+        set_cli_config(None)
+        cfg = get_cli_config((ctx.obj or {}).get('config_dir'))
         if cfg is None:
             raise CLIError("Configuration not available", exit_code=1)
 
@@ -679,6 +680,7 @@ def run(ctx, dry_run: bool, seed: Optional[int], output_dir: Optional[str],
             navigator = create_navigator(cfg.navigator)
             video_plume = create_video_plume(cfg.video_plume)
             run_plume_simulation(navigator, video_plume, cfg.simulation)
+            click.echo("Simulation completed")
         except Exception as e:
             logger.error(f"Simulation execution failed: {e}")
             raise SimulationError(f"Simulation failed: {e}") from e


### PR DESCRIPTION
## Summary
- standardize configuration validation and result reporting
- streamline run workflow and use navigation pipeline
- sanitize video plume paths and fix default config emission

## Testing
- `PYTHONPATH=src pytest tests/cli/test_cli_main.py::TestCLIConfigurationValidation::test_config_validate_command_success -q`
- `PYTHONPATH=src pytest tests/cli/test_cli_main.py::TestCLIConfigurationValidation::test_config_validate_command_failure -q`
- `PYTHONPATH=src pytest tests/cli/test_cli_main.py::TestCLIErrorHandling::test_unexpected_exception_handling -q`
- `PYTHONPATH=src pytest tests/cli/test_cli_main.py::TestCLIIntegrationScenarios::test_export_and_validation_workflow -q`
- `PYTHONPATH=src pytest tests/config/test_config_utils.py::TestPydanticSchemaValidation::test_navigator_config_validation_errors -q`
- `PYTHONPATH=src pytest tests/config/test_config_utils.py::TestPydanticSchemaValidation::test_video_plume_config_validation -q`
- `PYTHONPATH=src pytest tests/config/test_config_utils.py::TestEnvironmentVariableInterpolation::test_secure_environment_variable_handling -q`
- `PYTHONPATH=src pytest tests/config/test_config_utils.py::TestConfigurationSecurity::test_configuration_parameter_validation_boundaries -q`
- `PYTHONPATH=src pytest tests/config/test_config_utils.py::TestFactoryMethodIntegration::test_create_default_config -q`
- `PYTHONPATH=src pytest tests/cli/test_cli_main.py::TestCLIIntegrationScenarios::test_complete_simulation_workflow -q` *(fails: assert 1 == 0)*


------
https://chatgpt.com/codex/tasks/task_e_68b2fd9ce4dc8320aee8159101c7da4d