### PR TITLE
feat: add sensor introspection and telemetry

### DIFF
--- a/src/plume_nav_sim/core/sensors/base_sensor.py
+++ b/src/plume_nav_sim/core/sensors/base_sensor.py
@@ -732,10 +732,21 @@ class BaseSensor(ABC):
                 'cache_misses': 0,
                 'error_count': 0
             }
-            
+
             if self._logger:
                 self._logger.debug("Sensor performance metrics reset")
-    
+
+    def get_observation_space_info(self) -> Dict[str, Any]:
+        """Return generic observation space information for the sensor.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary with ``shape`` and ``dtype`` describing the sensor's
+            observation output. Subclasses may override this for custom outputs.
+        """
+        return {"shape": (1,), "dtype": np.float64}
+
     # Protected helper methods for use by concrete implementations
     
     def _execute_with_monitoring(

--- a/src/plume_nav_sim/core/sensors/binary_sensor.py
+++ b/src/plume_nav_sim/core/sensors/binary_sensor.py
@@ -235,7 +235,8 @@ class BinarySensor:
             'false_positives_applied': 0,
             'false_negatives_applied': 0,
             'hysteresis_activations': 0,
-            'total_calls': 0
+            'total_calls': 0,
+            'total_operations': 0
         }
         
         # Random number generation for noise modeling
@@ -320,19 +321,31 @@ class BinarySensor:
         
         try:
             # Input validation
-            if not isinstance(concentration_values, np.ndarray):
-                raise TypeError("concentration_values must be a numpy array")
-            if not isinstance(positions, np.ndarray):
-                raise TypeError("positions must be a numpy array")
-            
-            concentration_values = np.asarray(concentration_values, dtype=np.float64)
-            positions = np.asarray(positions, dtype=np.float64)
-            
-            # Ensure arrays are compatible
-            if concentration_values.ndim != 1:
-                raise ValueError(f"concentration_values must be 1D, got shape {concentration_values.shape}")
-            if positions.ndim != 2 or positions.shape[1] != 2:
+            single_agent = False
+
+            if np.isscalar(concentration_values):
+                concentration_values = np.array([concentration_values], dtype=np.float64)
+                single_agent = True
+            elif isinstance(concentration_values, np.ndarray):
+                concentration_values = np.asarray(concentration_values, dtype=np.float64)
+            else:
+                raise TypeError("concentration_values must be a numpy array or scalar")
+
+            if np.isscalar(positions):
+                raise TypeError("positions must be a sequence or array")
+            elif isinstance(positions, np.ndarray):
+                positions = np.asarray(positions, dtype=np.float64)
+            else:
+                positions = np.array(positions, dtype=np.float64)
+
+            if positions.ndim == 1:
+                if positions.shape[0] != 2:
+                    raise ValueError(f"Single position must have 2 coordinates, got {positions.shape[0]}")
+                positions = positions.reshape(1, -1)
+                single_agent = True
+            elif positions.ndim != 2 or positions.shape[1] != 2:
                 raise ValueError(f"positions must have shape (N, 2), got {positions.shape}")
+
             if len(concentration_values) != len(positions):
                 raise ValueError(f"Array length mismatch: {len(concentration_values)} vs {len(positions)}")
             
@@ -367,6 +380,7 @@ class BinarySensor:
                 self._performance_metrics['detection_times'].append(detection_time)
                 self._performance_metrics['total_detections'] += num_agents
                 self._performance_metrics['total_calls'] += 1
+                self._performance_metrics['total_operations'] += 1
                 
                 # Per-agent latency calculation
                 per_agent_latency = detection_time / num_agents if num_agents > 0 else 0
@@ -396,6 +410,8 @@ class BinarySensor:
                         num_agents=num_agents
                     )
             
+            if single_agent:
+                return bool(detections[0])
             return detections
             
         except Exception as e:
@@ -687,7 +703,8 @@ class BinarySensor:
             'false_positives_applied': 0,
             'false_negatives_applied': 0,
             'hysteresis_activations': 0,
-            'total_calls': 0
+            'total_calls': 0,
+            'total_operations': 0
         }
         
         # Log reset
@@ -710,30 +727,57 @@ class BinarySensor:
             Dict[str, Any]: Performance metrics including timing, throughput,
                 and efficiency statistics
         """
-        if not self._performance_metrics['detection_times']:
-            return {
-                'total_calls': 0,
-                'total_detections': 0,
-                'avg_latency_us': 0,
-                'throughput_detections_per_sec': 0,
-                'efficiency_score': 0
-            }
-        
-        detection_times = np.array(self._performance_metrics['detection_times'])
-        
-        return {
+        detection_times = np.array(self._performance_metrics['detection_times']) if self._performance_metrics['detection_times'] else None
+
+        metrics = {
+            'sensor_type': 'BinarySensor',
+            'total_operations': self._performance_metrics['total_operations'],
             'total_calls': self._performance_metrics['total_calls'],
             'total_detections': self._performance_metrics['total_detections'],
-            'avg_latency_us': float(np.mean(detection_times)),
-            'p95_latency_us': float(np.percentile(detection_times, 95)),
-            'max_latency_us': float(np.max(detection_times)),
-            'min_latency_us': float(np.min(detection_times)),
-            'latency_std_us': float(np.std(detection_times)),
-            'avg_per_agent_latency_us': float(np.mean(detection_times) / max(1, self._num_agents or 1)),
-            'throughput_detections_per_sec': float(self._num_agents / (np.mean(detection_times) / 1e6)) if self._num_agents else 0,
-            'efficiency_score': min(1.0, 1.0 / max(1.0, np.mean(detection_times))),  # 1.0 at 1μs, decreases with latency
-            'performance_violations': int(np.sum(detection_times > 1.0))  # Count of >1μs per agent
+            'avg_latency_us': 0,
+            'throughput_detections_per_sec': 0,
+            'efficiency_score': 0,
         }
+
+        if detection_times is not None and detection_times.size > 0:
+            metrics.update({
+                'avg_latency_us': float(np.mean(detection_times)),
+                'p95_latency_us': float(np.percentile(detection_times, 95)),
+                'max_latency_us': float(np.max(detection_times)),
+                'min_latency_us': float(np.min(detection_times)),
+                'latency_std_us': float(np.std(detection_times)),
+                'avg_per_agent_latency_us': float(np.mean(detection_times) / max(1, self._num_agents or 1)),
+                'throughput_detections_per_sec': float(self._num_agents / (np.mean(detection_times) / 1e6)) if self._num_agents else 0,
+                'efficiency_score': min(1.0, 1.0 / max(1.0, np.mean(detection_times))),
+                'performance_violations': int(np.sum(detection_times > 1.0)),
+            })
+
+        return metrics
+
+    def get_sensor_info(self) -> Dict[str, Any]:
+        """Expose capability and configuration information for the sensor."""
+        info = {
+            'sensor_type': 'BinarySensor',
+            'sensor_id': self._sensor_id,
+            'capabilities': [
+                'binary_detection',
+                'noise_modeling',
+                'vectorized_operations',
+            ],
+            'configuration': {
+                'threshold': self.config.threshold,
+                'hysteresis': self.config.hysteresis,
+                'false_positive_rate': self.config.false_positive_rate,
+                'false_negative_rate': self.config.false_negative_rate,
+            },
+        }
+        if self._logger:
+            self._logger.debug("BinarySensor info requested", info=info)
+        return info
+
+    def get_observation_space_info(self) -> Dict[str, Any]:
+        """Return observation space description for detection outputs."""
+        return {'shape': (1,), 'dtype': np.bool_}
 
     def measure(self, plume_state: Any, positions: np.ndarray) -> np.ndarray:
         """

--- a/src/plume_nav_sim/core/sensors/concentration_sensor.py
+++ b/src/plume_nav_sim/core/sensors/concentration_sensor.py
@@ -398,7 +398,8 @@ class ConcentrationSensor(BaseSensor):
             'filter_operations': 0,
             'saturation_events': 0,
             'noise_applications': 0,
-            'vectorized_operations': 0
+            'vectorized_operations': 0,
+            'total_measurements': 0
         })
         
         # Log sensor initialization
@@ -553,16 +554,16 @@ class ConcentrationSensor(BaseSensor):
             # Store last measurements for temporal filtering
             self._last_measurements = measured_concentrations.copy()
             self._measurement_count += num_agents
-            
+
             # Track performance metrics
+            self._performance_metrics['total_measurements'] += num_agents
             if self._enable_logging and start_time:
                 measurement_time = (time.perf_counter() - start_time) * 1000  # Convert to ms
                 self._performance_metrics['measurement_times'].append(measurement_time)
-                self._performance_metrics['total_measurements'] += num_agents
-                
+
                 if self._config.vectorized_ops and num_agents > 1:
                     self._performance_metrics['vectorized_operations'] += 1
-                
+
                 # Log detailed performance for debugging (reduced frequency)
                 if LOGURU_AVAILABLE and self._measurement_count % 100 == 0:
                     logger.trace(
@@ -573,7 +574,7 @@ class ConcentrationSensor(BaseSensor):
                         measurement_count=self._measurement_count,
                         drift_offset=self._total_drift
                     )
-                
+
                 # Check performance requirement (<0.1ms per agent)
                 if measurement_time > 0.1 * num_agents and LOGURU_AVAILABLE:
                     logger.warning(
@@ -584,8 +585,9 @@ class ConcentrationSensor(BaseSensor):
                         performance_degradation=True
                     )
             
-            # Always return array for consistent API with vectorized operations
-            return measured_concentrations
+            if measured_concentrations.shape[0] == 1:
+                return np.float64(measured_concentrations[0])
+            return measured_concentrations.astype(np.float64)
                 
         except Exception as e:
             if self._enable_logging and LOGURU_AVAILABLE:
@@ -1079,6 +1081,27 @@ class ConcentrationSensor(BaseSensor):
                 'performance_monitoring'
             ]
         }
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return configuration and performance metadata for the sensor."""
+        return {
+            'sensor_type': 'ConcentrationSensor',
+            'sensor_id': self._sensor_id,
+            'configuration': {
+                'dynamic_range': self._config.dynamic_range,
+                'resolution': self._config.resolution,
+                'noise_std': self._config.noise_std,
+            },
+            'performance': {
+                'total_measurements': self._performance_metrics['total_measurements'],
+                'total_calls': self._measurement_count,
+            },
+            'last_measurement': float(self._last_measurements[-1]) if isinstance(self._last_measurements, np.ndarray) and self._last_measurements.size > 0 else None,
+        }
+
+    def get_observation_space_info(self) -> Dict[str, Any]:
+        """Describe the measurement output space."""
+        return {'shape': (1,), 'dtype': np.float64}
 
 
 # Factory functions for configuration-driven instantiation


### PR DESCRIPTION
## Summary
- add default observation-space helper on BaseSensor
- expose sensor info, observation space, and telemetry counters for BinarySensor
- provide metadata accessor and observation space description on ConcentrationSensor
- cover introspection and vectorization scaling with new unit tests

## Testing
- `pytest tests/core/test_sensors.py::TestSensorFunctionality::test_binary_sensor_scalar_detection tests/core/test_sensors.py::TestSensorFunctionality::test_concentration_sensor_scalar_dtype tests/core/test_sensors.py::TestSensorFunctionality::test_concentration_sensor_quantitative_measurement tests/core/test_sensors.py::TestSensorIntrospection::test_binary_sensor_info_and_observation_space tests/core/test_sensors.py::TestSensorIntrospection::test_concentration_sensor_metadata_accessor tests/core/test_sensors.py::TestSensorIntrospection::test_performance_metrics_persist_after_reset tests/core/test_sensors.py::test_binary_sensor_vectorization_scaling -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a52ce9cc8320b4ec74e26b72eddb