### PR TITLE
fix: raise IOError for missing video files

### DIFF
--- a/src/odor_plume_nav/data/video_plume.py
+++ b/src/odor_plume_nav/data/video_plume.py
@@ -84,7 +84,10 @@ except ImportError:
     LOGGING_UTILS_AVAILABLE = False
     logger.debug("Enhanced logging utilities not available, using basic logging")
 
+# Shared error message when video file is missing
 VIDEO_FILE_MISSING_MSG = "Video file does not exist"
+
+__all__ = ["VideoPlume", "VIDEO_FILE_MISSING_MSG"]
 
 
 class VideoPlume:

--- a/src/plume_nav_sim/api/navigation.py
+++ b/src/plume_nav_sim/api/navigation.py
@@ -9,6 +9,7 @@ import numpy as np
 from typing import Optional, Dict, Any, Union, List, Tuple, Mapping
 from pathlib import Path
 import logging
+from odor_plume_nav.data.video_plume import VIDEO_FILE_MISSING_MSG
 
 logger = logging.getLogger(__name__)
 
@@ -88,14 +89,14 @@ def _validate_video_plume_config(config: Dict[str, Any]) -> None:
         
     Raises:
         ValueError: If configuration contains invalid values
-        FileNotFoundError: If video file does not exist
+        IOError: If video file does not exist
     """
     # Validate video_path
     if 'video_path' in config:
         video_path = Path(config['video_path'])
         # Check if the file exists (skip if it's a placeholder path)
         if str(video_path) != 'default_video.mp4' and not video_path.exists():
-            raise FileNotFoundError(f"Video file not found: {video_path}")
+            raise IOError(VIDEO_FILE_MISSING_MSG)
     
     # Validate flip parameter
     if 'flip' in config:

--- a/src/plume_nav_sim/data/video_plume.py
+++ b/src/plume_nav_sim/data/video_plume.py
@@ -10,6 +10,7 @@ import numpy as np
 from pathlib import Path
 from typing import Optional, Union, Any, Dict
 from plume_nav_sim.api.navigation import ConfigurationError
+from odor_plume_nav.data.video_plume import VIDEO_FILE_MISSING_MSG
 
 
 class VideoPlume:
@@ -51,13 +52,13 @@ class VideoPlume:
             **kwargs: Additional keyword arguments for extended functionality
         
         Raises:
-            FileNotFoundError: If the video file does not exist
+            IOError: If the video file does not exist
             ConfigurationError: If the video file cannot be opened
         """
         # Convert to Path object and validate existence
         self.video_path = Path(video_path)
         if not self.video_path.exists():
-            raise FileNotFoundError(f"Video file does not exist: {self.video_path}")
+            raise IOError(VIDEO_FILE_MISSING_MSG)
         
         # Store configuration parameters
         self.flip = flip

--- a/tests/test_video_plume_factory.py
+++ b/tests/test_video_plume_factory.py
@@ -27,6 +27,7 @@ from plume_nav_sim.api.navigation import (
 )
 from plume_nav_sim.data.video_plume import VideoPlume
 from plume_nav_sim.config.schemas import VideoPlumeConfig
+from odor_plume_nav.data.video_plume import VIDEO_FILE_MISSING_MSG
 
 # Try to import Hydra components for advanced testing
 try:
@@ -100,7 +101,7 @@ class TestCreateVideoPlume:
     
     def test_create_video_plume_file_not_found(self):
         """Test error handling for non-existent video file."""
-        with pytest.raises(FileNotFoundError, match="Video file does not exist"):
+        with pytest.raises(IOError, match=VIDEO_FILE_MISSING_MSG):
             create_video_plume(video_path="nonexistent_video.mp4")
     
     def test_create_video_plume_invalid_kernel_size(self, mock_exists):


### PR DESCRIPTION
## Summary
- centralize missing-video error message in VideoPlume
- validate video paths with IOError for consistency
- test VideoPlume factory when video file is missing

## Testing
- `pytest tests/test_video_plume_factory.py::TestCreateVideoPlume::test_create_video_plume_file_not_found tests/environments/test_video_plume.py::test_nonexistent_file -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb6d55908320ae10ef8aa9fcee4a