### PR TITLE
feat: allow zero kernel size

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -249,6 +249,9 @@ class VideoPlumeConfig(BaseModel):
     @classmethod
     def validate_kernel_size(cls, v):
         if v is not None:
+            if v == 0:
+                # A value of 0 disables kernel smoothing altogether
+                return 0
             if v < 0:
                 raise ValueError('kernel_size must be positive')
             if v % 2 == 0:

--- a/src/plume_nav_sim/data/video_plume.py
+++ b/src/plume_nav_sim/data/video_plume.py
@@ -5,12 +5,16 @@ This module provides the VideoPlume class for loading and processing video-based
 plume data for navigation simulations.
 """
 
-import cv2
-import numpy as np
+import logging
 from pathlib import Path
 from typing import Optional, Union, Any, Dict
+
+import cv2
+import numpy as np
 from plume_nav_sim.api.navigation import ConfigurationError
 from odor_plume_nav.data.video_plume import VIDEO_FILE_MISSING_MSG
+
+logger = logging.getLogger(__name__)
 
 
 class VideoPlume:
@@ -66,6 +70,10 @@ class VideoPlume:
         self.kernel_sigma = kernel_sigma
         self.grayscale = grayscale
         self.normalize = normalize
+
+        if self.kernel_size == 0:
+            # Log explicitly when smoothing is turned off
+            logger.info("Kernel smoothing disabled")
         
         # Store any additional keyword arguments as attributes
         for key, value in kwargs.items():
@@ -137,8 +145,8 @@ class VideoPlume:
         # Apply Gaussian kernel processing if specified
         if self.kernel_size > 0:
             processed = cv2.GaussianBlur(
-                processed, 
-                (self.kernel_size, self.kernel_size), 
+                processed,
+                (self.kernel_size, self.kernel_size),
                 self.kernel_sigma
             )
         

--- a/tests/test_video_plume_config.py
+++ b/tests/test_video_plume_config.py
@@ -1,0 +1,23 @@
+import pytest
+
+from plume_nav_sim.config import VideoPlumeConfig
+
+
+def test_kernel_size_zero_allows_disable_smoothing():
+    config = VideoPlumeConfig(
+        video_path="test.mp4",
+        kernel_size=0,
+        kernel_sigma=1.0,
+        _skip_validation=True,
+    )
+    assert config.kernel_size == 0
+
+@pytest.mark.parametrize("value, message", [(-1, "kernel_size must be positive"), (2, "kernel_size must be odd")])
+def test_kernel_size_invalid(value, message):
+    with pytest.raises(ValueError, match=message):
+        VideoPlumeConfig(
+            video_path="test.mp4",
+            kernel_size=value,
+            kernel_sigma=1.0,
+            _skip_validation=True,
+        )

--- a/tests/test_video_plume_logging.py
+++ b/tests/test_video_plume_logging.py
@@ -1,0 +1,15 @@
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plume_nav_sim.data.video_plume import VideoPlume
+
+
+def test_logs_when_kernel_smoothing_disabled(caplog):
+    video_path = Path(__file__).resolve().parent.parent / "test_video.mp4"
+    with patch.object(VideoPlume, "_init_video_capture", return_value=None):
+        with caplog.at_level(logging.INFO):
+            VideoPlume(video_path=video_path, kernel_size=0)
+    assert "Kernel smoothing disabled" in caplog.text


### PR DESCRIPTION
## Summary
- permit kernel_size=0 in VideoPlumeConfig to disable smoothing
- log when video plume uses raw frames without smoothing
- add tests for zero kernel size handling and logging

## Testing
- `pytest tests/test_video_plume_config.py tests/test_video_plume_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd7951e88320a723c9284d5f4f5f