### PR TITLE
feat(video-plume): support frame skipping and frame range selection

### DIFF
--- a/src/plume_nav_sim/api/navigation.py
+++ b/src/plume_nav_sim/api/navigation.py
@@ -123,6 +123,33 @@ def _validate_video_plume_config(config: Dict[str, Any]) -> None:
                 raise ValueError("kernel_sigma must be a positive number")
         except (ValueError, TypeError):
             raise ValueError("kernel_sigma must be a positive number")
+
+    # Validate frame range controls
+    if 'frame_skip' in config:
+        try:
+            frame_skip = int(config['frame_skip'])
+            if frame_skip <= 0:
+                raise ValueError("frame_skip must be a positive integer")
+        except (ValueError, TypeError):
+            raise ValueError("frame_skip must be a positive integer")
+
+    if 'start_frame' in config:
+        try:
+            start_frame = int(config['start_frame'])
+            if start_frame < 0:
+                raise ValueError("start_frame must be non-negative")
+        except (ValueError, TypeError):
+            raise ValueError("start_frame must be a non-negative integer")
+
+    if 'end_frame' in config and config['end_frame'] is not None:
+        try:
+            end_frame = int(config['end_frame'])
+            if end_frame < 0:
+                raise ValueError("end_frame must be non-negative")
+            if 'start_frame' in config and end_frame <= int(config['start_frame']):
+                raise ValueError("end_frame must be greater than start_frame")
+        except (ValueError, TypeError):
+            raise ValueError("end_frame must be a non-negative integer")
     
     # Validate width and height
     for param in ['width', 'height']:

--- a/src/plume_nav_sim/data/video_plume.py
+++ b/src/plume_nav_sim/data/video_plume.py
@@ -29,6 +29,17 @@ class VideoPlume:
         normalize (bool): Whether to normalize frame values
     """
     
+    @classmethod
+    def from_config(cls, cfg: Any) -> "VideoPlume":
+        """Create a VideoPlume from a configuration object or mapping."""
+        if hasattr(cfg, "model_dump"):
+            params = cfg.model_dump()
+        elif hasattr(cfg, "dict") and not isinstance(cfg, dict):
+            params = cfg.dict()
+        else:
+            params = dict(cfg)
+        return cls(**params)
+
     def __init__(
         self,
         video_path: Union[str, Path],
@@ -37,7 +48,10 @@ class VideoPlume:
         kernel_sigma: float = 1.0,
         grayscale: bool = False,
         normalize: bool = False,
-        **kwargs
+        frame_skip: int = 1,
+        start_frame: int = 0,
+        end_frame: Optional[int] = None,
+        **kwargs,
     ):
         """
         Initialize the VideoPlume with the specified parameters.
@@ -49,6 +63,9 @@ class VideoPlume:
             kernel_sigma: Sigma value for Gaussian kernel processing
             grayscale: Whether to convert frames to grayscale
             normalize: Whether to normalize frame values
+            frame_skip: Number of frames to skip between reads (>=1)
+            start_frame: Starting frame index (>=0)
+            end_frame: Optional ending frame index (exclusive)
             **kwargs: Additional keyword arguments for extended functionality
         
         Raises:
@@ -60,12 +77,23 @@ class VideoPlume:
         if not self.video_path.exists():
             raise IOError(VIDEO_FILE_MISSING_MSG)
         
+        # Validate frame range parameters early
+        if frame_skip <= 0:
+            raise ValueError("frame_skip must be positive")
+        if start_frame < 0:
+            raise ValueError("start_frame must be non-negative")
+        if end_frame is not None and end_frame <= start_frame:
+            raise ValueError("end_frame must be greater than start_frame")
+
         # Store configuration parameters
         self.flip = flip
         self.kernel_size = kernel_size
         self.kernel_sigma = kernel_sigma
         self.grayscale = grayscale
         self.normalize = normalize
+        self.frame_skip = frame_skip
+        self.start_frame = start_frame
+        self.end_frame = end_frame
         
         # Store any additional keyword arguments as attributes
         for key, value in kwargs.items():
@@ -73,6 +101,15 @@ class VideoPlume:
         
         # Initialize video capture and validate
         self._init_video_capture()
+
+        # Validate frame range against video properties
+        if self.start_frame >= self.frame_count:
+            raise ValueError("start_frame is beyond video length")
+        if self.end_frame is not None and self.end_frame > self.frame_count:
+            raise ValueError("end_frame is beyond video length")
+
+        # Track current frame for sequential reads
+        self._current_frame = self.start_frame
     
     def _init_video_capture(self):
         """Initialize the OpenCV VideoCapture and validate it can be opened."""
@@ -87,32 +124,28 @@ class VideoPlume:
         self.fps = self._cap.get(cv2.CAP_PROP_FPS)
         self.frame_count = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT))
     
-    def get_frame(self, frame_index: Optional[int] = None) -> np.ndarray:
-        """
-        Get a frame from the video.
-        
-        Args:
-            frame_index: Index of the frame to retrieve. If None, gets the next frame.
-            
-        Returns:
-            The requested frame as a numpy array
-            
-        Raises:
-            ValueError: If the frame index is out of range
-            RuntimeError: If frame reading fails
-        """
-        if frame_index is not None:
-            if frame_index < 0 or frame_index >= self.frame_count:
+    def get_frame(self, frame_index: Optional[int] = None) -> Optional[np.ndarray]:
+        """Retrieve a processed frame using frame skip logic."""
+        # Determine the actual frame to fetch
+        max_frame = self.end_frame if self.end_frame is not None else self.frame_count
+
+        if frame_index is None:
+            actual_idx = self._current_frame
+            self._current_frame += self.frame_skip
+        else:
+            if frame_index < 0:
                 raise ValueError(f"Frame index {frame_index} is out of range")
-            self._cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
-        
+            actual_idx = self.start_frame + frame_index * self.frame_skip
+
+        if actual_idx < self.start_frame or actual_idx >= max_frame:
+            return None
+
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, actual_idx)
         ret, frame = self._cap.read()
         if not ret:
             raise RuntimeError("Failed to read frame from video")
-        
-        # Apply processing based on configuration
-        processed_frame = self._process_frame(frame)
-        return processed_frame
+
+        return self._process_frame(frame)
     
     def _process_frame(self, frame: np.ndarray) -> np.ndarray:
         """
@@ -161,10 +194,33 @@ class VideoPlume:
         # This is a placeholder implementation
         # In a real implementation, this would extract concentration from the current frame
         return 0.0
-    
+
+    @property
+    def duration(self) -> float:
+        return 0.0 if self.fps == 0 else self.frame_count / self.fps
+
+    @property
+    def shape(self) -> tuple:
+        return (self.height, self.width)
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return basic video metadata including frame controls."""
+        return {
+            "width": self.width,
+            "height": self.height,
+            "fps": self.fps,
+            "frame_count": self.frame_count,
+            "duration": self.duration,
+            "shape": self.shape,
+            "frame_skip": self.frame_skip,
+            "start_frame": self.start_frame,
+            "end_frame": self.end_frame,
+        }
+
     def reset(self):
         """Reset the video to the beginning."""
-        self._cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, self.start_frame)
+        self._current_frame = self.start_frame
     
     def close(self):
         """Close the video capture and release resources."""

--- a/tests/test_video_plume_frame_controls.py
+++ b/tests/test_video_plume_frame_controls.py
@@ -1,0 +1,56 @@
+import numpy as np
+from unittest.mock import patch
+from plume_nav_sim.data.video_plume import VideoPlume
+import cv2
+
+
+class DummyCapture:
+    def __init__(self):
+        self.position = 0
+        self.opened = True
+        self.props = {
+            cv2.CAP_PROP_FRAME_WIDTH: 10,
+            cv2.CAP_PROP_FRAME_HEIGHT: 8,
+            cv2.CAP_PROP_FPS: 20.0,
+            cv2.CAP_PROP_FRAME_COUNT: 30,
+        }
+
+    def isOpened(self):
+        return self.opened
+
+    def get(self, prop):
+        return self.props.get(prop, 0)
+
+    def set(self, prop, value):
+        if prop == cv2.CAP_PROP_POS_FRAMES:
+            self.position = value
+
+    def read(self):
+        frame = np.full((8, 10, 3), self.position, dtype=np.uint8)
+        return True, frame
+
+    def release(self):
+        self.opened = False
+
+
+def test_frame_selection_and_bounds(mock_exists):
+    dummy = DummyCapture()
+    with patch('plume_nav_sim.data.video_plume.cv2.VideoCapture', return_value=dummy):
+        plume = VideoPlume('video.mp4', frame_skip=2, start_frame=1, end_frame=6)
+        assert plume.get_frame(0) is not None
+        assert dummy.position == 1
+        plume.get_frame(1)
+        assert dummy.position == 3
+        plume.get_frame(2)
+        assert dummy.position == 5
+        assert plume.get_frame(3) is None
+
+
+def test_metadata_includes_frame_controls(mock_exists):
+    dummy = DummyCapture()
+    with patch('plume_nav_sim.data.video_plume.cv2.VideoCapture', return_value=dummy):
+        plume = VideoPlume('video.mp4', frame_skip=3, start_frame=2, end_frame=10)
+        metadata = plume.get_metadata()
+        assert metadata['frame_skip'] == 3
+        assert metadata['start_frame'] == 2
+        assert metadata['end_frame'] == 10


### PR DESCRIPTION
## Summary
- add frame_skip, start_frame, and end_frame parameters to VideoPlume with validation
- expose frame controls via get_metadata and from_config
- validate frame range params in video plume config logic
- test frame skipping behavior and metadata reporting

## Testing
- `pytest tests/test_video_plume_frame_controls.py -q`
- `pytest tests/test_video_plume_factory.py::TestCreateVideoPlume::test_create_video_plume_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd517db48320820142e2bf2206ac