### PR TITLE
feat: log frame retrieval and metadata events

### DIFF
--- a/tests/test_video_plume_logging.py
+++ b/tests/test_video_plume_logging.py
@@ -1,9 +1,12 @@
 import logging
+import json
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import cv2
 import pytest
+from loguru import logger
 
 from plume_nav_sim.data.video_plume import VideoPlume
 
@@ -67,3 +70,35 @@ def test_binds_context_in_workflow_metadata(tmp_path, mock_exists):
             ctx.bind_context.reset_mock()
             plume.get_workflow_metadata()
             assert ctx.bind_context.called
+
+
+def test_get_frame_logs_context(mock_exists):
+    dummy = DummyCapture()
+    with patch('plume_nav_sim.data.video_plume.cv2.VideoCapture', return_value=dummy):
+        plume = VideoPlume(video_path="video.mp4")
+        buffer = StringIO()
+        handler_id = logger.add(buffer, serialize=True)
+        plume.get_frame(0)
+        logger.remove(handler_id)
+    lines = [line for line in buffer.getvalue().splitlines() if line.strip()]
+    assert lines, "No logs captured"
+    record = json.loads(lines[-1])
+    extra = record["record"]["extra"]
+    assert "correlation_id" in extra
+    assert extra["frame_index"] == 0
+
+
+def test_get_metadata_logs_context(mock_exists):
+    dummy = DummyCapture()
+    with patch('plume_nav_sim.data.video_plume.cv2.VideoCapture', return_value=dummy):
+        plume = VideoPlume(video_path="video.mp4")
+        buffer = StringIO()
+        handler_id = logger.add(buffer, serialize=True)
+        plume.get_metadata()
+        logger.remove(handler_id)
+    lines = [line for line in buffer.getvalue().splitlines() if line.strip()]
+    assert lines, "No logs captured"
+    record = json.loads(lines[-1])
+    extra = record["record"]["extra"]
+    assert "correlation_id" in extra
+    assert extra.get("operation") == "get_metadata"


### PR DESCRIPTION
## Summary
- add structured logging for video frame retrieval events
- log metadata access with correlation IDs
- test logging output for required JSON fields

## Testing
- `pytest tests/test_video_plume_logging.py::test_get_frame_logs_context -q`
- `pytest tests/test_video_plume_logging.py::test_get_metadata_logs_context -q`
- `pytest -q` *(fails: 'AttributeError: 'NoneType' object has no attribute 'Table'')*
- `pip install pyarrow -q` *(fails: No matching distribution found for pyarrow)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c146be24832080b785652ed01264