### PR TITLE
fix(sensor): retain base metrics on gradient reset

### DIFF
--- a/src/plume_nav_sim/core/sensors/gradient_sensor.py
+++ b/src/plume_nav_sim/core/sensors/gradient_sensor.py
@@ -1337,15 +1337,19 @@ class GradientSensor(BaseSensor):
     
     def reset_performance_metrics(self) -> None:
         """Reset performance metrics for new monitoring period."""
-        self._performance_metrics = {
+        super().reset_performance_metrics()
+        if not self._enable_performance_monitoring:
+            return
+
+        self._performance_metrics.update({
             'computation_times': [],
             'total_computations': 0,
             'cache_hits': 0,
             'cache_misses': 0,
             'numerical_warnings': 0,
-            'edge_case_count': 0
-        }
-        
+            'edge_case_count': 0,
+        })
+
         if self._logger:
             self._logger.debug("Performance metrics reset", sensor_id=self._sensor_id)
 

--- a/tests/core/test_sensors.py
+++ b/tests/core/test_sensors.py
@@ -964,18 +964,20 @@ class TestSensorMetadata:
         # Perform gradient computations
         for i in range(3):
             result = sensor.compute_gradient_with_metadata(mock_plume_state, positions)
-        
+
         # Test comprehensive metadata from gradient result
         assert isinstance(result.metadata, dict)
         assert 'sensor_id' in result.metadata
         assert 'timestamp' in result.metadata
-        
+
         # Test performance metrics
+        sensor.reset()
         metrics = sensor.get_performance_metrics()
         assert isinstance(metrics, dict)
         assert 'sensor_type' in metrics
         assert metrics['sensor_type'] == 'GradientSensor'
         assert 'total_computations' in metrics
+        assert 'total_operations' in metrics
 
 
 class TestSensorIntrospection:


### PR DESCRIPTION
## Summary
- ensure `GradientSensor.reset_performance_metrics` preserves base counters
- verify performance metrics after reset include total operations

## Testing
- `pytest tests/core/test_sensors.py::TestSensorMetadata::test_gradient_sensor_metadata -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c1bf305c8320a893d75f3ac0932b