### PR TITLE
fix: centralize orientation validation and add bounds tests

### DIFF
--- a/tests/test_orientation_validation.py
+++ b/tests/test_orientation_validation.py
@@ -1,0 +1,30 @@
+import pytest
+from src.plume_nav_sim.config.schemas import SingleAgentConfig, NavigatorConfig, MultiAgentConfig
+
+
+@pytest.mark.parametrize("cls, kwargs", [
+    (SingleAgentConfig, {"orientation": -1}),
+    (NavigatorConfig, {"orientation": -1}),
+])
+def test_orientation_lower_bound(cls, kwargs):
+    with pytest.raises(ValueError, match="ensure this value is greater than or equal to 0"):
+        cls(**kwargs)
+
+
+@pytest.mark.parametrize("cls, kwargs", [
+    (SingleAgentConfig, {"orientation": 361}),
+    (NavigatorConfig, {"orientation": 361}),
+])
+def test_orientation_upper_bound(cls, kwargs):
+    with pytest.raises(ValueError, match="ensure this value is less than or equal to 360"):
+        cls(**kwargs)
+
+
+@pytest.mark.parametrize("orientations, msg", [
+    ([-1.0], "ensure this value is greater than or equal to 0"),
+    ([361.0], "ensure this value is less than or equal to 360"),
+])
+def test_multi_agent_orientation_bounds(orientations, msg):
+    positions = [[0.0, 0.0] for _ in orientations]
+    with pytest.raises(ValueError, match=msg):
+        MultiAgentConfig(positions=positions, orientations=orientations)


### PR DESCRIPTION
## Summary
- centralize orientation validation in `schemas.py` and reuse across config classes
- ensure all single- and multi-agent orientations enforce 0-360° bounds
- add unit tests for lower and upper orientation bounds

## Testing
- `pytest tests/test_orientation_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d16e96b083208b083aa1f4e03734