### PR TITLE
feat: expose seed context manager utility

### DIFF
--- a/src/plume_nav_sim/utils/seed_utils.py
+++ b/src/plume_nav_sim/utils/seed_utils.py
@@ -15,6 +15,9 @@ from odor_plume_nav.utils.seed_manager import (
     SeedManager,
     get_current_seed,
 )
+from odor_plume_nav.utils.seed_utils import (
+    seed_context_manager as _seed_context_manager,
+)
 
 
 @dataclass
@@ -52,4 +55,14 @@ def validate_deterministic_behavior(*args, **kwargs) -> bool:  # pragma: no cove
     return True
 
 
-__all__ = ["set_global_seed", "get_seed_context", "SeedContext", "validate_deterministic_behavior"]
+# Re-export with preserved documentation
+seed_context_manager = _seed_context_manager
+
+
+__all__ = [
+    "set_global_seed",
+    "get_seed_context",
+    "SeedContext",
+    "validate_deterministic_behavior",
+    "seed_context_manager",
+]

--- a/tests/core/test_seed_context_manager.py
+++ b/tests/core/test_seed_context_manager.py
@@ -1,0 +1,22 @@
+import random
+import numpy as np
+from odor_plume_nav.utils.seed_manager import SeedManager
+
+from plume_nav_sim.utils.seed_utils import seed_context_manager
+
+
+def test_seed_context_manager_is_deterministic():
+    """Ensure seed_context_manager applies deterministic seeding for RNGs."""
+    manager = SeedManager()
+    manager.set_seed(999)
+    with seed_context_manager(123):
+        inside_random1 = random.random()
+        inside_numpy1 = np.random.rand()
+
+    manager.set_seed(999)
+    with seed_context_manager(123):
+        inside_random2 = random.random()
+        inside_numpy2 = np.random.rand()
+
+    assert inside_random1 == inside_random2
+    assert inside_numpy1 == inside_numpy2


### PR DESCRIPTION
## Summary
- re-export `seed_context_manager` from `odor_plume_nav.utils.seed_utils`
- test deterministic seeding via `seed_context_manager`

## Testing
- `pytest tests/core/test_seed_context_manager.py::test_seed_context_manager_is_deterministic -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d353dc58832092f87b650a7244f6