### PR TITLE
fix: serialize VideoPlumeConfig video_path as string

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -9,7 +9,7 @@ from enum import Enum
 from pathlib import Path
 import logging
 import re
-from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator, field_serializer
 try:
     from hydra.core.config_store import ConfigStore
     cs = ConfigStore.instance()
@@ -337,14 +337,9 @@ class VideoPlumeConfig(BaseModel):
                 raise ValueError('end_frame must be greater than start_frame')
         return values
 
-    @property
-    def video_path_str(self) -> str:
-        return str(self.video_path)
-
-    def model_dump(self, *args, **kwargs):
-        data = super().model_dump(*args, **kwargs)
-        data['video_path'] = self.video_path_str
-        return data
+    @field_serializer('video_path')
+    def serialize_video_path(self, v):
+        return str(v)
 
     model_config = ConfigDict(extra="allow")
 

--- a/tests/test_video_plume_config_video_path.py
+++ b/tests/test_video_plume_config_video_path.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from plume_nav_sim.config.schemas import VideoPlumeConfig
+from pydantic import BaseModel
 
 
 def test_invalid_video_path_raises_and_logs(caplog):
@@ -24,3 +25,10 @@ def test_env_pattern_kept_as_string():
     cfg = VideoPlumeConfig(video_path=pattern)
     assert cfg.video_path == pattern
     assert cfg.model_dump()["video_path"] == pattern
+
+
+def test_base_model_dump_serializes_to_string():
+    path = Path("test_video.mp4")
+    cfg = VideoPlumeConfig(video_path=path)
+    data = BaseModel.model_dump(cfg)
+    assert data["video_path"] == "test_video.mp4"


### PR DESCRIPTION
## Summary
- serialize `VideoPlumeConfig.video_path` as a string via `@field_serializer`
- extend tests to verify base `model_dump` outputs a string

## Testing
- `pytest tests/test_video_plume_config_video_path.py::test_base_model_dump_serializes_to_string -q`
- `pytest tests/test_video_plume_config_video_path.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*

------
https://chatgpt.com/codex/tasks/task_e_68b4d3e0901083208b641b3bd1aa5930