### PR TITLE
refactor: return environment values as strings

### DIFF
--- a/src/plume_nav_sim/config/utils.py
+++ b/src/plume_nav_sim/config/utils.py
@@ -198,18 +198,18 @@ def resolve_env_value(value: str, default: str = "") -> str:
         env_value = os.environ.get(env_var)
         if env_value is not None:
             logger.debug("Resolved env var %s as %s", env_var, env_value)
-            return env_value
+            return str(env_value)
         if use_default != "":
             logger.debug("Using default value for %s: %s", env_var, use_default)
-            return use_default
+            return str(use_default)
         raise KeyError(f"Environment variable '{env_var}' not found")
 
     if '${oc.env:' in value:
         logger.debug("Interpolation pattern detected but not full match; returning default: %s", default)
-        return default
+        return str(default)
 
     logger.debug("No interpolation; returning value unchanged: %s", value)
-    return value
+    return str(value)
 
 
 # Re-export schemas for convenience


### PR DESCRIPTION
## Summary
- remove type conversion helpers for environment variables
- ensure `resolve_env_value` returns raw string values
- update tests to expect strings and demonstrate schema-based type enforcement

## Testing
- `pytest tests/test_config_utils.py::TestEnvironmentVariableInterpolation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d3e43ea483208706feb34703e8a4