### PR TITLE
feat: add API compatibility utilities

### DIFF
--- a/src/plume_nav_sim/envs/__init__.py
+++ b/src/plume_nav_sim/envs/__init__.py
@@ -153,43 +153,46 @@ except Exception as e:  # pragma: no cover - optional component
         extra={"metric_type": "environment_limitation", "error": str(e)}
     ) if LOGGING_AVAILABLE else None
 
-# Import compatibility layer for dual API support
+# Import compatibility utilities for dual API support
 try:
-    from plume_nav_sim.envs.compat import (
-        CompatibilityEnvWrapper,
-        detect_api_context,
-        create_environment_factory,
-        LegacyWrapper
+    from . import compat
+    from .compat import (
+        APIVersionResult,
+        CompatibilityMode,
+        detect_api_version,
+        wrap_environment,
     )
     __all__.extend([
-        "CompatibilityEnvWrapper",
-        "detect_api_context", 
-        "create_environment_factory",
-        "LegacyWrapper"
+        "APIVersionResult",
+        "CompatibilityMode",
+        "detect_api_version",
+        "wrap_environment",
+        "compat",
     ])
     COMPAT_LAYER_AVAILABLE = True
     logger.info(
-        "Compatibility layer available for dual API support",
+        "Compatibility utilities available for dual API support",
         extra={
             "metric_type": "environment_capability",
             "feature": "dual_api_support",
             "legacy_support": True,
             "modern_support": True,
-            "auto_detection": True
+            "auto_detection": True,
         }
     ) if LOGGING_AVAILABLE else None
-except ImportError as e:
-    CompatibilityEnvWrapper = None
-    detect_api_context = None
-    create_environment_factory = None
-    LegacyWrapper = None
+except Exception as e:  # pragma: no cover - optional component
+    compat = None
+    APIVersionResult = None
+    CompatibilityMode = None
+    detect_api_version = None
+    wrap_environment = None
     COMPAT_LAYER_AVAILABLE = False
     logger.warning(
-        f"Compatibility layer not available: {e}, single API mode only",
+        f"Compatibility utilities not available: {e}, single API mode only",
         extra={
             "metric_type": "environment_limitation",
             "missing_feature": "dual_api_support",
-            "error": str(e)
+            "error": str(e),
         }
     ) if LOGGING_AVAILABLE else None
 

--- a/src/plume_nav_sim/envs/compat.py
+++ b/src/plume_nav_sim/envs/compat.py
@@ -1,0 +1,142 @@
+"""Compatibility utilities for dual Gym/Gymnasium API support."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+APIVersionResult = namedtuple(
+    "APIVersionResult", ["is_legacy", "confidence", "detection_method"]
+)
+
+
+@dataclass
+class CompatibilityMode:
+    """Configuration for wrapping environments to a specific API format."""
+
+    use_legacy_api: bool
+    detection: APIVersionResult
+    measure_timing: bool = False
+    correlation_id: Optional[str] = None
+
+
+def detect_api_version() -> APIVersionResult:
+    """Detect whether the caller expects the legacy Gym API.
+
+    This uses a simple stack inspection strategy: if any frame in the call stack
+    defines a ``gym`` module that appears to be the legacy package (``__name__`` is
+    ``"gym"``), the caller is treated as legacy. The result of this detection is
+    logged for diagnostic purposes.
+    """
+
+    legacy_detected = False
+    stack = inspect.stack()
+    for frame_info in stack[1:]:
+        frame = frame_info.frame
+        gym_obj = None
+        if "gym" in frame.f_globals:
+            gym_obj = frame.f_globals["gym"]
+        elif "gym" in frame.f_locals:
+            gym_obj = frame.f_locals["gym"]
+        if gym_obj is None:
+            continue
+        name = getattr(gym_obj, "__name__", "")
+        if name == "gym":
+            legacy_detected = True
+            break
+    # Confidence is high if we detected legacy usage
+    confidence = 0.9 if legacy_detected else 0.5
+    result = APIVersionResult(legacy_detected, confidence, "stack_inspection")
+    logger.info(
+        "API version detection",
+        extra={
+            "is_legacy": result.is_legacy,
+            "confidence": result.confidence,
+            "method": result.detection_method,
+        },
+    )
+    return result
+
+
+def wrap_environment(env: Any, mode: CompatibilityMode):
+    """Wrap an environment to convert between legacy and modern API formats.
+
+    The wrapper inspects ``mode.use_legacy_api`` to determine the desired output
+    format. Conversions between 4-tuple (legacy) and 5-tuple (modern) step results
+    as well as between ``reset`` return styles are logged.
+    """
+
+    if env is None:
+        raise ValueError("Environment to wrap cannot be None")
+
+    class EnvWrapper:
+        def __init__(self, inner):
+            self._env = inner
+
+        def __getattr__(self, item):
+            return getattr(self._env, item)
+
+        def reset(self, *args, **kwargs):
+            result = self._env.reset(*args, **kwargs)
+            if mode.use_legacy_api:
+                if isinstance(result, tuple):
+                    if len(result) == 2:
+                        obs, info = result
+                        logger.debug("Converting reset output from 2-tuple to obs for legacy API")
+                        return obs
+                    elif len(result) == 1:
+                        return result[0]
+                    else:
+                        raise ValueError("Unexpected reset return length for legacy API")
+                logger.debug("Reset output already legacy compatible")
+                return result
+            else:
+                if isinstance(result, tuple):
+                    if len(result) == 2:
+                        return result
+                    elif len(result) == 1:
+                        obs = result[0]
+                        logger.debug("Converting reset output from obs to (obs, {}) for modern API")
+                        return obs, {}
+                    else:
+                        raise ValueError("Unexpected reset return length for modern API")
+                logger.debug("Converting reset output from obs to (obs, {}) for modern API")
+                return result, {}
+
+        def step(self, action, *args, **kwargs):
+            result = self._env.step(action, *args, **kwargs)
+            if not isinstance(result, tuple):
+                raise ValueError("Environment step must return a tuple")
+            if mode.use_legacy_api:
+                if len(result) == 5:
+                    obs, reward, terminated, truncated, info = result
+                    done = bool(terminated) or bool(truncated)
+                    logger.debug("Converting step output from 5-tuple to 4-tuple for legacy API")
+                    return obs, reward, done, info
+                if len(result) == 4:
+                    logger.debug("Step output already legacy compatible")
+                    return result
+                raise ValueError("Unexpected step return length for legacy API")
+            else:
+                if len(result) == 4:
+                    obs, reward, done, info = result
+                    logger.debug("Converting step output from 4-tuple to 5-tuple for modern API")
+                    return obs, reward, bool(done), False, info
+                if len(result) == 5:
+                    logger.debug("Step output already modern compatible")
+                    return result
+                raise ValueError("Unexpected step return length for modern API")
+
+    return EnvWrapper(env)
+
+__all__ = [
+    "APIVersionResult",
+    "CompatibilityMode",
+    "detect_api_version",
+    "wrap_environment",
+]

--- a/tests/test_env_compat.py
+++ b/tests/test_env_compat.py
@@ -1,0 +1,76 @@
+import logging
+import types
+from collections import namedtuple
+import pytest
+
+# The compat module will be created later; we still import to show tests expecting it
+from plume_nav_sim.envs import compat as compat_module
+
+# We expect the module to provide APIVersionResult, CompatibilityMode, detect_api_version, wrap_environment
+
+
+def make_dummy_gym_module():
+    dummy = types.SimpleNamespace(__name__='gym', __version__='0.26.0')
+    return dummy
+
+
+def test_detect_api_version_legacy(monkeypatch):
+    dummy_gym = make_dummy_gym_module()
+
+    def legacy_caller():
+        gym = dummy_gym  # noqa: F841 local variable named gym
+        return compat_module.detect_api_version()
+
+    result = legacy_caller()
+    assert result.is_legacy is True
+    assert result.detection_method == 'stack_inspection'
+
+
+def test_detect_api_version_modern():
+    result = compat_module.detect_api_version()
+    assert result.is_legacy is False
+    assert result.detection_method == 'stack_inspection'
+
+
+class ModernEnv:
+    def reset(self):
+        return 'obs', {'meta': 1}
+
+    def step(self, action):  # pragma: no cover - action unused
+        return 'obs', 1.0, False, False, {'meta': 2}
+
+
+class LegacyEnv:
+    def reset(self):
+        return 'obs'
+
+    def step(self, action):  # pragma: no cover - action unused
+        return 'obs', 1.0, True, {'meta': 3}
+
+
+def test_wrap_environment_to_legacy(caplog):
+    caplog.set_level(logging.DEBUG)
+    dummy_detection = compat_module.APIVersionResult(True, 1.0, 'test')
+    mode = compat_module.CompatibilityMode(True, dummy_detection, False, 'abc')
+    env = compat_module.wrap_environment(ModernEnv(), mode)
+    obs = env.reset()
+    assert obs == 'obs'
+    assert 'Converting reset output' in caplog.text
+    obs2, reward, done, info = env.step(0)
+    assert (obs2, reward, done, info) == ('obs', 1.0, False, {'meta': 2})
+    assert 'Converting step output' in caplog.text
+
+
+def test_wrap_environment_to_modern(caplog):
+    caplog.set_level(logging.DEBUG)
+    dummy_detection = compat_module.APIVersionResult(False, 1.0, 'test')
+    mode = compat_module.CompatibilityMode(False, dummy_detection, False, 'def')
+    env = compat_module.wrap_environment(LegacyEnv(), mode)
+    obs, info = env.reset()
+    assert (obs, info) == ('obs', {})
+    assert 'Converting reset output' in caplog.text
+    obs2, reward, terminated, truncated, info2 = env.step(0)
+    assert (obs2, reward, terminated, truncated, info2) == (
+        'obs', 1.0, True, False, {'meta': 3}
+    )
+    assert 'Converting step output' in caplog.text


### PR DESCRIPTION
## Summary
- add stack-inspection-based API detection
- implement compatibility wrapper to convert between legacy and modern step/reset formats
- expose compatibility utilities through envs package

## Testing
- `pytest tests/test_env_compat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d666aa148320943788bc3a6c1dfd