### PR TITLE
feat(utils): add seed context manager wrapper with logging

### DIFF
--- a/tests/core/test_seed_context_manager.py
+++ b/tests/core/test_seed_context_manager.py
@@ -20,3 +20,39 @@ def test_seed_context_manager_is_deterministic():
 
     assert inside_random1 == inside_random2
     assert inside_numpy1 == inside_numpy2
+
+
+def test_seed_context_manager_restores_state_and_logs():
+    """Seed context manager restores RNG state and logs lifecycle events."""
+    from loguru import logger
+
+    # Baseline sequence without context manager
+    random.seed(7)
+    np.random.seed(7)
+    random.random()
+    np.random.rand()
+    expected_random = random.random()
+    expected_numpy = np.random.rand()
+
+    # Use context manager and ensure state restoration
+    random.seed(7)
+    np.random.seed(7)
+    random.random()
+    np.random.rand()
+
+    messages = []
+    sink_id = logger.add(messages.append, format="{message}")
+    with seed_context_manager(123):
+        random.random()
+        np.random.rand()
+    logger.remove(sink_id)
+
+    after_random = random.random()
+    after_numpy = np.random.rand()
+
+    assert after_random == expected_random
+    assert after_numpy == expected_numpy
+
+    log_text = " ".join(messages).lower()
+    assert "establishing seed context" in log_text
+    assert "restored rng state" in log_text


### PR DESCRIPTION
## Summary
- wrap upstream `seed_context_manager` to restore Python and NumPy RNG state and log lifecycle events
- document wrapper and expose in `utils` module
- test seed restoration and logging behaviour

## Testing
- `PYTHONPATH=src pytest tests/core/test_seed_context_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d67e53348320a1a64a4a8cc3e706