### PR TITLE
feat: add environment id alias and normalization

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -20,8 +20,11 @@ import warnings
 import inspect
 import sys
 import atexit
+import logging
 
 __version__ = "1.0.0"
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # LEGACY GYM DETECTION AND DEPRECATION WARNING SYSTEM
@@ -132,20 +135,43 @@ def _register_gymnasium_environments():
     try:
         import gymnasium
         from gymnasium.envs.registration import register
-        
+
+        env_kwargs = {
+            'api_version': 'gymnasium',
+            'return_format': '5-tuple',
+            'enable_extensibility_hooks': True,
+        }
+
         # Register primary Gymnasium environment
         register(
             id='PlumeNavSim-v0',
             entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
             max_episode_steps=1000,
             reward_threshold=500.0,
-            kwargs={
-                'api_version': 'gymnasium',
-                'return_format': '5-tuple',
-                'enable_extensibility_hooks': True,
-            }
+            kwargs=dict(env_kwargs),
         )
-        
+        logger.info(
+            "Registered PlumeNavSim-v0 environment",
+            extra={"metric_type": "environment_registration", "env_id": "PlumeNavSim-v0"},
+        )
+
+        # Register snake_case alias
+        register(
+            id='plume_nav_sim_v0',
+            entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
+            max_episode_steps=1000,
+            reward_threshold=500.0,
+            kwargs=dict(env_kwargs),
+        )
+        logger.info(
+            "Registered plume_nav_sim_v0 alias for PlumeNavSim-v0",
+            extra={
+                "metric_type": "environment_registration",
+                "env_id": "plume_nav_sim_v0",
+                "alias_for": "PlumeNavSim-v0",
+            },
+        )
+
         # Register legacy compatibility environment
         register(
             id='OdorPlumeNavigation-v1',
@@ -158,7 +184,7 @@ def _register_gymnasium_environments():
                 'enable_extensibility_hooks': False,
             }
         )
-        
+
         return True
         
     except ImportError:

--- a/src/plume_nav_sim/api/navigation.py
+++ b/src/plume_nav_sim/api/navigation.py
@@ -537,6 +537,21 @@ def visualize_simulation_results(
     return visualize_plume_simulation(positions, orientations, **kwargs)
 
 
+def _normalize_environment_id(env_id: str) -> str:
+    """Normalize environment identifiers to handle hyphen/underscore variants."""
+    key = env_id.replace("-", "").replace("_", "").lower()
+    if key == "plumenavsimv0":
+        target = "plume_nav_sim_v0" if "_" in env_id else "PlumeNavSim-v0"
+        if env_id != target:
+            logger.info(
+                "Using environment alias '%s' for '%s'",
+                target,
+                env_id,
+            )
+        return target
+    return env_id
+
+
 def create_gymnasium_environment(
     config: Optional[Dict[str, Any]] = None,
     **kwargs
@@ -562,11 +577,12 @@ def create_gymnasium_environment(
     
     # Extract environment_id, default to PlumeNavSim-v0
     environment_id = merged_config.pop('environment_id', 'PlumeNavSim-v0')
-    
+    environment_id = _normalize_environment_id(environment_id)
+
     # Try to create the real environment
     try:
         import gymnasium as gym
-        
+
         # Create environment using gymnasium.make
         env = gym.make(environment_id, **merged_config)
         return env

--- a/src/plume_nav_sim/envs/__init__.py
+++ b/src/plume_nav_sim/envs/__init__.py
@@ -544,6 +544,43 @@ def register_environments() -> Dict[str, bool]:
                     "frame_cache_default": "lru"
                 }
             ) if LOGGING_AVAILABLE else None
+
+            try:
+                gym_modern.register(
+                    id='plume_nav_sim_v0',
+                    entry_point='plume_nav_sim.envs.plume_navigation_env:PlumeNavigationEnv',
+                    max_episode_steps=1000,
+                    reward_threshold=100.0,
+                    nondeterministic=False,
+                    kwargs={
+                        'use_gymnasium_api': True,
+                        'api_version': '0.29.x',
+                        'enable_extensibility_hooks': True,
+                        'frame_cache_mode': 'lru'
+                    }
+                )
+                registration_results['plume_nav_sim_v0'] = True
+                logger.info(
+                    "Registered plume_nav_sim_v0 alias for PlumeNavSim-v0",
+                    extra={
+                        "metric_type": "environment_registration",
+                        "env_id": "plume_nav_sim_v0",
+                        "alias_for": "PlumeNavSim-v0",
+                        "api_type": "gymnasium",
+                        "api_version": "0.29.x"
+                    }
+                ) if LOGGING_AVAILABLE else None
+            except Exception as e:
+                registration_results['plume_nav_sim_v0'] = False
+                logger.error(
+                    f"Failed to register plume_nav_sim_v0: {e}",
+                    extra={
+                        "metric_type": "registration_error",
+                        "env_id": "plume_nav_sim_v0",
+                        "error_type": type(e).__name__,
+                        "error_message": str(e)
+                    }
+                ) if LOGGING_AVAILABLE else None
         except Exception as e:
             registration_results['PlumeNavSim-v0'] = False
             logger.error(

--- a/tests/api/test_navigation_environment_alias.py
+++ b/tests/api/test_navigation_environment_alias.py
@@ -1,0 +1,13 @@
+from unittest.mock import patch
+import logging
+from plume_nav_sim.api.navigation import create_gymnasium_environment
+
+
+def test_create_gymnasium_environment_normalizes_id(caplog):
+    with patch('gymnasium.make') as mock_make:
+        with caplog.at_level(logging.INFO):
+            create_gymnasium_environment(environment_id='PlumeNavSim_v0')
+        mock_make.assert_called_once()
+        called_id = mock_make.call_args[0][0]
+        assert called_id == 'plume_nav_sim_v0'
+    assert 'environment alias' in caplog.text

--- a/tests/environments/test_environment_alias_registration.py
+++ b/tests/environments/test_environment_alias_registration.py
@@ -1,0 +1,11 @@
+import gymnasium as gym
+
+
+def test_snake_case_environment_id_registered():
+    import plume_nav_sim.envs  # Trigger environment registration
+    assert 'PlumeNavSim-v0' in gym.envs.registry
+    assert 'plume_nav_sim_v0' in gym.envs.registry
+    spec_main = gym.envs.registry['PlumeNavSim-v0']
+    spec_alias = gym.envs.registry['plume_nav_sim_v0']
+    assert spec_main.entry_point == spec_alias.entry_point
+    assert spec_main.kwargs == spec_alias.kwargs


### PR DESCRIPTION
## Summary
- register `plume_nav_sim_v0` as a snake_case alias for `PlumeNavSim-v0`
- normalize environment IDs in `create_gymnasium_environment`
- add tests for alias registration and normalization

## Testing
- `pytest tests/environments/test_environment_alias_registration.py tests/api/test_navigation_environment_alias.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d66a4d3c8320baa92b79d9c0fbf1