### PR TITLE
feat(shims): implement gym_make wrapper

### DIFF
--- a/src/plume_nav_sim/shims/__init__.py
+++ b/src/plume_nav_sim/shims/__init__.py
@@ -38,7 +38,7 @@ import warnings
 
 try:
     # Import the primary gym_make compatibility function
-    from plume_nav_sim.shims.gym_make import gym_make
+    from .gym_make import gym_make
     _gym_make_available = True
     
 except ImportError as e:

--- a/src/plume_nav_sim/shims/gym_make.py
+++ b/src/plume_nav_sim/shims/gym_make.py
@@ -1,0 +1,49 @@
+"""Legacy-compatible environment creation shim for Gymnasium."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Any
+
+import gymnasium as gym
+
+from plume_nav_sim import warn_if_legacy_env_usage
+from plume_nav_sim.envs.compat import (
+    CompatibilityMode,
+    detect_api_version,
+    wrap_environment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def gym_make(env_id: str, **kwargs: Any):
+    """Create a Gymnasium environment with legacy gym compatibility.
+
+    This shim normalizes environment identifiers, emits a deprecation warning,
+    and wraps the returned environment so that legacy callers receive 4-tuple
+    step/reset semantics when necessary.
+    """
+    if not isinstance(env_id, str):
+        raise TypeError("env_id must be a string")
+
+    warnings.warn(
+        "Using gym_make is deprecated and will be removed in v1.0. "
+        "Use gymnasium.make() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    logger.info("gym_make called", extra={"env_id": env_id})
+
+    normalized_id = warn_if_legacy_env_usage(env_id)
+
+    detection = detect_api_version()
+    mode = CompatibilityMode(use_legacy_api=detection.is_legacy, detection=detection)
+
+    env = gym.make(normalized_id, **kwargs)
+    env = wrap_environment(env, mode)
+    return env
+
+
+__all__ = ["gym_make"]

--- a/tests/test_gym_make_wrapper.py
+++ b/tests/test_gym_make_wrapper.py
@@ -1,0 +1,41 @@
+import warnings
+import gymnasium as gym
+import pytest
+
+from plume_nav_sim.envs.compat import APIVersionResult
+
+
+def test_gym_make_normalizes_and_wraps(monkeypatch, caplog):
+    """gym_make should normalize env IDs, emit deprecation, and wrap for legacy API."""
+    import plume_nav_sim.shims.gym_make as gm
+
+    # Dummy environment returning modern 5-tuple results
+    class DummyEnv(gym.Env):
+        def reset(self, *, seed=None, options=None):
+            return 0, {}
+
+        def step(self, action):
+            return 0, 0.0, False, False, {}
+
+    called = {}
+
+    def fake_make(env_id, **kwargs):
+        called['env_id'] = env_id
+        called['kwargs'] = kwargs
+        return DummyEnv()
+
+    monkeypatch.setattr(gym, "make", fake_make)
+
+    def fake_detect():
+        return APIVersionResult(True, 1.0, "test")
+
+    monkeypatch.setattr(gm, "detect_api_version", fake_detect)
+
+    caplog.set_level("INFO")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        env = gm.gym_make("OdorPlumeNavigation-v1")
+    assert called['env_id'] == "PlumeNavSim-v0"
+    assert any(isinstance(warn.message, DeprecationWarning) for warn in w)
+    assert len(env.step(0)) == 4
+    assert any("gym_make" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `gym_make` shim that normalizes IDs, warns on usage, and wraps environments for legacy API support
- expose shim from `shims.__init__`
- test shim behavior

## Testing
- `pytest tests/test_gym_make_wrapper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4d75a1140832089104eef4b6043a2