### PR TITLE
feat(core): raise error on unknown controller kwargs

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -498,13 +498,16 @@ class BaseController:
             'frame_cache_misses': 0
         }
         
+        # Known kwargs
+        cache_memory_limit_mb = kwargs.pop("cache_memory_limit_mb", 2048)
+
         # Frame cache integration
         self._frame_cache = None
         if FRAME_CACHE_AVAILABLE and self._frame_cache_mode != "none":
             try:
                 self._frame_cache = FrameCache(
                     mode=self._frame_cache_mode,
-                    memory_limit_mb=kwargs.get('cache_memory_limit_mb', 2048),
+                    memory_limit_mb=cache_memory_limit_mb,
                     enable_statistics=True
                 )
             except Exception as e:
@@ -534,6 +537,12 @@ class BaseController:
                     pass
         else:
             self._logger = None
+
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs.keys()))
+            log = self._logger if self._logger is not None else logger
+            log.error(f"Unexpected keyword arguments: {unknown}")
+            raise TypeError(f"Unexpected keyword arguments: {unknown}")
     
     # NavigatorProtocol properties for v1.0 architecture
     

--- a/tests/core/test_controller_unknown_kwargs.py
+++ b/tests/core/test_controller_unknown_kwargs.py
@@ -1,0 +1,9 @@
+import pytest
+
+from plume_nav_sim.core.controllers import BaseController
+
+
+def test_base_controller_rejects_unknown_kwargs():
+    with pytest.raises(TypeError) as exc_info:
+        BaseController(unexpected=123)
+    assert "unexpected" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- raise error when BaseController receives unknown keyword arguments
- add unit test ensuring BaseController rejects unexpected kwargs

## Testing
- `pytest tests/core/test_controller_unknown_kwargs.py -q`
- `pytest tests/core -q` *(fails: pre-existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d82a0a3483209872aa0eaad07e8e