### PR TITLE
fix(controller): copy speeds on assignment

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -1814,7 +1814,7 @@ class MultiAgentController(BaseController):
     @speeds.setter
     def speeds(self, value: Union[List[float], np.ndarray]) -> None:
         """Set agent speeds with validation against array shape and max speeds."""
-        arr = np.asarray(value, dtype=float)
+        arr = np.array(value, dtype=float, copy=True)
         if arr.shape != self._speeds.shape:
             raise ValueError(
                 f"speeds must have shape {self._speeds.shape}, got {arr.shape}"
@@ -1823,6 +1823,13 @@ class MultiAgentController(BaseController):
             raise ValueError("speeds must be non-negative")
         if np.any(arr > self._max_speeds):
             raise ValueError("speeds cannot exceed max_speeds")
+        copied = not np.shares_memory(arr, value)
+        if self._logger:
+            self._logger.debug(
+                "speeds reassigned",
+                num_agents=self.num_agents,
+                copied=copied,
+            )
         self._speeds = arr
     
     @property

--- a/tests/core/test_controller_speeds_copy.py
+++ b/tests/core/test_controller_speeds_copy.py
@@ -1,0 +1,16 @@
+import numpy as np
+from plume_nav_sim.core.controllers import MultiAgentController
+
+
+def test_speeds_assignment_creates_copy():
+    positions = np.zeros((2, 2))
+    controller = MultiAgentController(
+        positions=positions,
+        orientations=np.zeros(2),
+        speeds=np.zeros(2),
+        max_speeds=np.full(2, 10.0),
+    )
+    new_speeds = np.array([1.0, 2.0])
+    controller.speeds = new_speeds
+    new_speeds[0] = 5.0
+    assert controller.speeds[0] == 1.0


### PR DESCRIPTION
## Summary
- ensure MultiAgentController copies speed assignments and logs reassignment
- add regression test for speed copying behavior

## Testing
- `pytest tests/core/test_controller_speeds_copy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd2323e88320a9da6d83eeeff93d