### PR TITLE
feat(env): add explicit API mode selection

### DIFF
--- a/tests/test_use_gymnasium_api_param.py
+++ b/tests/test_use_gymnasium_api_param.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+from unittest.mock import patch
+
+from plume_nav_sim.envs.plume_navigation_env import PlumeNavigationEnv
+
+
+def make_env(**kwargs):
+    return PlumeNavigationEnv(video_path="nonexistent.mp4", **kwargs)
+
+
+def test_use_gymnasium_api_true_returns_gymnasium_tuples():
+    env = make_env(use_gymnasium_api=True)
+    result = env.reset()
+    assert isinstance(result, tuple) and len(result) == 2
+    action = env.action_space.sample()
+    step_result = env.step(action)
+    assert len(step_result) == 5
+
+
+def test_use_gymnasium_api_false_returns_legacy_tuples():
+    env = make_env(use_gymnasium_api=False)
+    result = env.reset()
+    assert not isinstance(result, tuple)
+    action = env.action_space.sample()
+    step_result = env.step(action)
+    assert len(step_result) == 4
+
+
+def test_force_legacy_overrides_gymnasium_param():
+    env = make_env(use_gymnasium_api=True, _force_legacy_api=True)
+    result = env.reset()
+    assert not isinstance(result, tuple)
+    action = env.action_space.sample()
+    step_result = env.step(action)
+    assert len(step_result) == 4
+
+
+def test_detect_legacy_caller_used_when_param_absent():
+    with patch("plume_nav_sim.envs.plume_navigation_env._detect_legacy_gym_caller", return_value=True) as mock_detect:
+        env = make_env()
+        mock_detect.assert_called_once()
+        result = env.reset()
+        assert not isinstance(result, tuple)
+        action = env.action_space.sample()
+        step_result = env.step(action)
+        assert len(step_result) == 4


### PR DESCRIPTION
## Summary
- allow PlumeNavigationEnv to accept `use_gymnasium_api` for explicit API mode selection
- return legacy 1-tuple on reset when in legacy mode and log step format
- add tests for Gymnasium vs legacy API behavior

## Testing
- `PYTHONPATH=src pytest tests/test_use_gymnasium_api_param.py -q`
- `PYTHONPATH=src pytest tests/api/test_api.py::TestGymnasiumAPICompliance::test_gymnasium_step_returns_5_tuple -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd3fa48c83208d610e4fb73369db