### PR TITLE
feat: add max_duration validator

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -369,7 +369,7 @@ class SimulationConfig(BaseModel):
     save_animation: Optional[bool] = False
     animation_path: Optional[str] = None
     # Runtime/IO parameters for compatibility with tests
-    max_duration: Optional[float] = Field(None, gt=0)
+    max_duration: Optional[float] = Field(None)
     fps: Optional[int] = Field(None, gt=0)
     real_time: Optional[bool] = False
     output_directory: Optional[str] = None
@@ -393,6 +393,15 @@ class SimulationConfig(BaseModel):
         """Validate that dt is positive if provided."""
         if v is not None and v <= 0:
             raise ValueError("dt (timestep) must be positive")
+        return v
+
+    @field_validator('max_duration')
+    @classmethod
+    def validate_max_duration(cls, v):
+        """Validate that max_duration is positive if provided."""
+        if v is not None and v <= 0:
+            logger.debug("Invalid max_duration: %s", v)
+            raise ValueError("ensure this value is greater than 0")
         return v
     
     @field_validator('width', 'height')

--- a/tests/config/test_simulation_max_duration.py
+++ b/tests/config/test_simulation_max_duration.py
@@ -1,0 +1,12 @@
+import logging
+import pytest
+from pydantic import ValidationError
+from src.plume_nav_sim.config.schemas import SimulationConfig
+
+
+def test_max_duration_negative_logs_and_raises(caplog):
+    """SimulationConfig should log and raise on non-positive max_duration."""
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+            SimulationConfig(max_duration=-1)
+    assert "Invalid max_duration" in caplog.text


### PR DESCRIPTION
## Summary
- validate SimulationConfig.max_duration is positive
- log invalid max_duration values
- add regression test for max_duration validation

## Testing
- `pytest tests/config/test_simulation_max_duration.py::test_max_duration_negative_logs_and_raises -q`
- `pytest tests/config/test_config_utils.py::TestConfigurationSecurity::test_configuration_parameter_validation_boundaries -q` *(fails: Video file not found: /valid/path.mp4)*

------
https://chatgpt.com/codex/tasks/task_e_68b4df9c5bfc83209bef022c658b8bfa