### PR TITLE
feat(config): add validation for simulation max duration

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -369,7 +369,7 @@ class SimulationConfig(BaseModel):
     save_animation: Optional[bool] = False
     animation_path: Optional[str] = None
     # Runtime/IO parameters for compatibility with tests
-    max_duration: Optional[float] = Field(None, gt=0)
+    max_duration: Optional[float] = Field(None)
     fps: Optional[int] = Field(None, gt=0)
     real_time: Optional[bool] = False
     output_directory: Optional[str] = None
@@ -401,6 +401,16 @@ class SimulationConfig(BaseModel):
         """Validate that width and height are positive if provided."""
         if v is not None and v <= 0:
             raise ValueError("Environment dimensions must be positive")
+        return v
+
+    @field_validator('max_duration')
+    @classmethod
+    def validate_max_duration(cls, v):
+        """Validate that max_duration is positive if provided."""
+        if v is not None and v <= 0:
+            logger.error("max_duration is not positive: %s", v)
+            raise ValueError("ensure this value is greater than 0")
+        logger.debug("max_duration validated: %s", v)
         return v
 
     model_config = ConfigDict(extra="allow")

--- a/tests/config/test_simulation_config_max_duration.py
+++ b/tests/config/test_simulation_config_max_duration.py
@@ -1,0 +1,12 @@
+import logging
+import pytest
+from pydantic import ValidationError
+
+from plume_nav_sim.config import SimulationConfig
+
+
+def test_max_duration_must_be_positive_logs_error(caplog):
+    caplog.set_level(logging.ERROR, logger="plume_nav_sim.config.schemas")
+    with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+        SimulationConfig(max_duration=0)
+    assert any("max_duration" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- ensure simulation `max_duration` is positive with logging
- test `SimulationConfig` max duration validation

## Testing
- `pytest tests/config/test_simulation_config_max_duration.py -q`
- `pytest tests/config/test_config_utils.py -k configuration_parameter_validation_boundaries -q` *(fails: Video file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dfb4b4788320b40eda16b5f92d6b