### PR TITLE
feat(protocols): add time-based performance monitoring

### DIFF
--- a/src/plume_nav_sim/protocols/performance_monitor.py
+++ b/src/plume_nav_sim/protocols/performance_monitor.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Protocol, Dict, runtime_checkable
+from typing import Protocol, Dict, Any, runtime_checkable
 
 
 @runtime_checkable
 class PerformanceMonitorProtocol(Protocol):
     """Interface for collecting simulation performance metrics."""
 
-    def record_step(self, duration_ms: float, label: str | None = None) -> None:
-        """Record metrics for a single simulation step."""
+    def record_step_time(self, seconds: float) -> None:
+        """Record metrics for a single simulation step in seconds."""
 
-    def export(self) -> Dict[str, float]:
-        """Return accumulated performance statistics."""
+    def get_summary(self) -> Dict[str, Any]:
+        """Return aggregated performance statistics."""
+
+    # Backward compatibility shims
+    def record_step(self, duration_ms: float, label: str | None = None) -> None:
+        """Record metrics for a single simulation step in milliseconds."""
+        self.record_step_time(duration_ms / 1000.0)
+
+    def export(self) -> Dict[str, Any]:
+        """Return aggregated performance statistics."""
+        return self.get_summary()
 
 
 __all__ = ["PerformanceMonitorProtocol"]

--- a/tests/protocols/test_performance_monitor_adapter.py
+++ b/tests/protocols/test_performance_monitor_adapter.py
@@ -14,6 +14,15 @@ def test_record_step_logs_and_exports(caplog):
     assert exported["step"] == pytest.approx(5.0)
 
 
+def test_record_step_time_and_get_summary(caplog):
+    monitor = PerformanceMonitor()
+    with caplog.at_level(logging.INFO):
+        monitor.record_step_time(0.005)
+    assert "step" in caplog.text
+    summary = monitor.get_summary()
+    assert summary["step"] == pytest.approx(0.005)
+
+
 def test_record_step_invalid_duration():
     monitor = PerformanceMonitor()
     with pytest.raises(ValueError):

--- a/tests/protocols/test_simulation_protocols.py
+++ b/tests/protocols/test_simulation_protocols.py
@@ -11,9 +11,23 @@ logger = logging.getLogger(__name__)
 PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
     "NavigatorProtocol": {
         "methods": {
-            "reset": lambda self: None,
-            "step": lambda self, action: None,
-            "get_state": lambda self: {},
+            "positions": None,
+            "orientations": None,
+            "speeds": None,
+            "max_speeds": None,
+            "angular_velocities": None,
+            "num_agents": 1,
+            "reset": lambda self, *args, **kwargs: None,
+            "step": lambda self, env_array, dt=1.0: None,
+            "sample_odor": lambda self, env_array: 0.0,
+            "sample_multiple_sensors": (
+                lambda self, env_array, sensor_distance=None, sensor_angle=None,
+                num_sensors=None, layout_name=None: 0.0
+            ),
+            "compute_additional_obs": lambda self, base_obs: {},
+            "compute_extra_reward": lambda self, base_reward, info: 0.0,
+            "on_episode_end": lambda self, final_info: None,
+            "get_observation_space_info": lambda self: {},
         },
         "missing": "step",
     },
@@ -44,10 +58,12 @@ PROTOCOL_SPECS: Dict[str, Dict[str, Any]] = {
     },
     "PerformanceMonitorProtocol": {
         "methods": {
+            "record_step_time": lambda self, seconds: None,
+            "get_summary": lambda self: {"dummy": 0.0},
             "record_step": lambda self, duration_ms, label=None: None,
             "export": lambda self: {"dummy": 0.0},
         },
-        "missing": "export",
+        "missing": "get_summary",
     },
 }
 


### PR DESCRIPTION
## Summary
- expand performance monitor protocol with `record_step_time` and `get_summary`
- keep legacy `record_step`/`export` delegating to the new API
- update performance monitor implementation and protocol tests

## Testing
- `pytest tests/protocols/test_performance_monitor_adapter.py tests/protocols/test_simulation_protocols.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e681e7e88320b5807d88e84743e4