### PR TITLE
feat: add optional memory hooks for NavigatorProtocol

### DIFF
--- a/src/plume_nav_sim/protocols/navigator.py
+++ b/src/plume_nav_sim/protocols/navigator.py
@@ -43,6 +43,31 @@ class NavigatorProtocol(Protocol):
     ) -> np.ndarray:
         """Sample odor using a multi-sensor configuration."""
 
+    # --- Optional observation and memory hooks ---
+    def observe(self, sensor_output: Any) -> Dict[str, Any]:
+        """Process raw sensor output into a normalized observation.
+
+        Implementations may simply return an empty dictionary if no
+        observation processing is required. Invalid input types should
+        raise ``TypeError`` to prevent silent failures.
+        """
+
+    def load_memory(self, memory_data: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        """Load internal memory state for cognitive navigation strategies.
+
+        The default expectation is a no-op returning ``None`` when memory
+        is disabled. Implementations should raise ``TypeError`` when
+        ``memory_data`` is provided with an incompatible type.
+        """
+
+    def save_memory(self) -> Optional[Dict[str, Any]]:
+        """Return a serialisable snapshot of the current memory state.
+
+        When memory is disabled, implementations should return ``None``.
+        Invalid internal memory representations should trigger a
+        ``TypeError`` to surface misconfigurations loudly.
+        """
+
     # --- Extensibility hooks ---
     def compute_additional_obs(self, base_obs: dict) -> dict:
         """Compute additional observation components."""


### PR DESCRIPTION
## Summary
- expose optional observe/load_memory/save_memory hooks on `NavigatorProtocol`
- add logging and type validation stubs in `BaseController`
- expand tests for controller memory hooks

## Testing
- `pytest tests/core/test_protocol_navigator.py::TestNavigatorProtocolMemoryInterface -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e908d3508320b396ff81e34eed0d