### PR TITLE
feat: add step tracking to simulation results

### DIFF
--- a/tests/integration/test_modular_simulation.py
+++ b/tests/integration/test_modular_simulation.py
@@ -1784,6 +1784,14 @@ def test_integration_test_suite_completeness():
     assert coverage_percentage >= 100, f"Test coverage {coverage_percentage:.1f}% below 100% requirement"
 
 
+def test_simulation_results_have_step_count_and_success():
+    """Simulation results expose step count and success attributes."""
+    ctx = SimulationContext.create()
+    results = ctx.run_simulation()
+    assert hasattr(results, "step_count")
+    assert hasattr(results, "success")
+
+
 if __name__ == "__main__":
     # Enhanced test execution with comprehensive reporting
     pytest.main([


### PR DESCRIPTION
## Summary
- track executed steps and success state in SimulationResults
- log instantiation of SimulationResults for easier debugging
- cover new fields with integration test

## Testing
- `pytest tests/integration/test_modular_simulation.py::test_simulation_results_have_step_count_and_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4eab0f50c8320bf4a4469cf2e269c