### PR TITLE
fix(core): deep copy saved memory state

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -105,6 +105,7 @@ Notes:
 import contextlib
 import time
 import warnings
+import copy
 from typing import Optional, Union, Any, Tuple, List, Dict, TypeVar, Callable
 from dataclasses import dataclass, field
 import dataclasses
@@ -867,10 +868,15 @@ class BaseController:
             raise TypeError("memory state must be a dict")
 
         log = self._logger if self._logger is not None else logger
-        if self._memory_state is not None:
-            log.debug("memory state saved", memory_keys=list(self._memory_state.keys()))
+        if self._memory_state is None:
+            log.debug("memory state saved", deep_copy=False)
+            return None
 
-        return self._memory_state
+        memory_copy = copy.deepcopy(self._memory_state)
+        log.debug(
+            "memory state saved", deep_copy=True, memory_keys=list(self._memory_state.keys())
+        )
+        return memory_copy
     
     def update_memory(self, observation: Dict[str, Any], action: Any, reward: float, info: Dict[str, Any]) -> None:
         """

--- a/tests/core/test_protocol_navigator.py
+++ b/tests/core/test_protocol_navigator.py
@@ -2066,10 +2066,12 @@ class TestNavigatorProtocolMemoryInterface:
         
         loaded_memory = controller.load_memory(test_memory)
         assert loaded_memory == test_memory
-        
+
         # Test saving memory data
         saved_memory = controller.save_memory()
         assert saved_memory == test_memory
+        # Returned object should be a different instance than internal memory
+        assert saved_memory is not controller._memory_state
     
     def test_memory_interface_optional_compliance(self) -> None:
         """Test that memory interface methods are optional and don't enforce usage."""


### PR DESCRIPTION
## Summary
- return deep copy of controller memory when saving
- log whether memory was copied
- ensure test checks identity of saved memory

## Testing
- `pytest tests/core/test_protocol_navigator.py::TestNavigatorProtocolMemoryInterface::test_memory_interface_enabled_behavior -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4eceefbac8320a0f6b730de4a434d