### PR TITLE
fix(core): always return deep copy from save_memory

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -867,14 +867,12 @@ class BaseController:
         if self._memory_state is not None and not isinstance(self._memory_state, dict):
             raise TypeError("memory state must be a dict")
 
-        log = self._logger if self._logger is not None else logger
-        if self._memory_state is None:
-            log.debug("memory state saved", deep_copy=False)
-            return None
-
         memory_copy = copy.deepcopy(self._memory_state)
+        log = self._logger if self._logger is not None else logger
         log.debug(
-            "memory state saved", deep_copy=True, memory_keys=list(self._memory_state.keys())
+            "memory state saved",
+            deep_copy=self._memory_state is not None,
+            memory_keys=list(self._memory_state.keys()) if self._memory_state else None,
         )
         return memory_copy
     

--- a/tests/core/test_protocol_navigator.py
+++ b/tests/core/test_protocol_navigator.py
@@ -2072,6 +2072,9 @@ class TestNavigatorProtocolMemoryInterface:
         assert saved_memory == test_memory
         # Returned object should be a different instance than internal memory
         assert saved_memory is not controller._memory_state
+        # Modifying the returned memory should not affect internal memory state
+        saved_memory["episode_count"] = 999
+        assert controller._memory_state["episode_count"] == test_memory["episode_count"]
     
     def test_memory_interface_optional_compliance(self) -> None:
         """Test that memory interface methods are optional and don't enforce usage."""


### PR DESCRIPTION
## Summary
- ensure `save_memory` deep copies memory when enabled and log copy status
- test that saved memory is separate instance and mutations don't affect internal state

## Testing
- `pytest tests/core/test_protocol_navigator.py::TestNavigatorProtocolMemoryInterface::test_memory_interface_enabled_behavior -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0952aec8320b5f63333e916544f