### PR TITLE
feat(core): add step timing summary

### DIFF
--- a/tests/protocols/test_performance_monitor_adapter.py
+++ b/tests/protocols/test_performance_monitor_adapter.py
@@ -5,25 +5,29 @@ import pytest
 from plume_nav_sim.core.simulation import PerformanceMonitor
 
 
-def test_record_step_logs_and_exports(caplog):
-    monitor = PerformanceMonitor()
-    with caplog.at_level(logging.INFO):
-        monitor.record_step(5.0, label="step")
-    assert "step" in caplog.text
-    exported = monitor.export()
-    assert exported["step"] == pytest.approx(5.0)
-
-
 def test_record_step_time_and_get_summary(caplog):
     monitor = PerformanceMonitor()
     with caplog.at_level(logging.INFO):
         monitor.record_step_time(0.005)
-    assert "step" in caplog.text
+    assert "Recorded step duration" in caplog.text
     summary = monitor.get_summary()
-    assert summary["step"] == pytest.approx(0.005)
+    assert summary["avg_step_time_ms"] == pytest.approx(5.0)
+    assert summary["max_step_time_ms"] == pytest.approx(5.0)
+    assert summary["total_steps"] == 1
+    assert summary["performance_target_met"]
 
 
-def test_record_step_invalid_duration():
+def test_record_step_delegates_to_record_step_time(caplog):
+    monitor = PerformanceMonitor()
+    with caplog.at_level(logging.INFO):
+        monitor.record_step(5.0)
+    assert "Recorded step duration" in caplog.text
+    summary = monitor.get_summary()
+    assert summary["avg_step_time_ms"] == pytest.approx(5.0)
+    assert summary["total_steps"] == 1
+
+
+def test_record_step_time_invalid_duration():
     monitor = PerformanceMonitor()
     with pytest.raises(ValueError):
-        monitor.record_step(-1.0, label="bad")
+        monitor.record_step_time(-0.001)


### PR DESCRIPTION
## Summary
- remove old PerformanceMonitor stub to prevent naming collisions
- track step times with logging and summary metrics
- cover new step time API with tests

## Testing
- `pytest tests/protocols/test_performance_monitor_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0adebd48320b7aa018243ded6a8