### PR TITLE
feat: record step duration with seconds

### DIFF
--- a/src/odor_plume_nav/core/simulation.py
+++ b/src/odor_plume_nav/core/simulation.py
@@ -253,6 +253,18 @@ class PerformanceMonitor:
         
         # Check performance thresholds
         self._check_performance_thresholds()
+
+    def record_step_time(self, seconds: float, label: str | None = None) -> None:
+        """Compatibility wrapper accepting durations in seconds.
+
+        Parameters
+        ----------
+        seconds : float
+            Time taken for the step in seconds.
+        label : str | None
+            Optional label for the recorded duration.
+        """
+        self.record_step(seconds)
     
     def _check_performance_thresholds(self) -> None:
         """Check if performance is below target and record warnings."""
@@ -731,8 +743,11 @@ def run_simulation(
 
                     # Record performance metrics
                     step_duration = time.perf_counter() - step_start_time
+                    sim_logger.debug(
+                        f"Step {step} duration: {step_duration:.6f}s"
+                    )
                     if performance_monitor is not None:
-                        performance_monitor.record_step(step_duration)
+                        performance_monitor.record_step_time(step_duration, label="step")
 
                     # Checkpoint creation
                     if (sim_config.checkpoint_interval > 0 and 

--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -2210,11 +2210,14 @@ def run_simulation(
                             sim_logger.debug(f"Visualization update failed at step {step}: {e}")
 
                     # Record performance metrics
-                    step_duration_ms = (time.perf_counter() - step_start_time) * 1000
+                    step_duration = time.perf_counter() - step_start_time
+                    sim_logger.debug(
+                        f"Step {step} duration: {step_duration:.6f}s"
+                    )
                     if performance_monitor is not None:
-                        performance_monitor.record_step(step_duration_ms, label="step")
+                        performance_monitor.record_step_time(step_duration, label="step")
                         if hook_duration > 0:
-                            performance_monitor.record_step(hook_duration * 1000, label="hook")
+                            performance_monitor.record_step_time(hook_duration, label="hook")
                     
                     # Collect component metrics if enabled
                     if component_metrics_collection and (step + 1) % 100 == 0:  # Every 100 steps

--- a/tests/core/test_performance_monitor_calls.py
+++ b/tests/core/test_performance_monitor_calls.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock, patch
+
+from plume_nav_sim.core.simulation import run_simulation as run_plume_simulation
+from odor_plume_nav.core.simulation import run_simulation as run_odor_simulation
+import numpy as np
+
+
+class DummySpace:
+    def sample(self):
+        return 0
+
+
+class DummyEnv:
+    action_space = DummySpace()
+    observation_space = None
+
+    def reset(self, seed=None, options=None):
+        return 0, {}
+
+    def step(self, action):
+        return 0, 0.0, False, False, {}
+
+    def close(self):
+        pass
+
+
+def test_run_simulation_records_step_time_plume_nav_sim():
+    env = DummyEnv()
+    with patch('plume_nav_sim.core.simulation.PerformanceMonitor') as MockMonitor:
+        mock_monitor = Mock()
+        mock_monitor.record_step_time = Mock()
+        MockMonitor.return_value = mock_monitor
+        run_plume_simulation(env, num_steps=1)
+        mock_monitor.record_step_time.assert_called()
+
+
+def test_run_simulation_records_step_time_odor_plume_nav():
+    class DummyNavigator:
+        num_agents = 1
+
+        def __init__(self):
+            self.positions = np.zeros((1, 2))
+            self.orientations = np.zeros(1)
+
+        def step(self, frame, dt: float):
+            pass
+
+        def sample_odor(self, frame):
+            return 0.0
+
+    class DummyVideoPlume:
+        frame_count = 2
+
+        def get_frame(self, idx):
+            return None
+
+    navigator = DummyNavigator()
+    video_plume = DummyVideoPlume()
+    with patch('odor_plume_nav.core.simulation.PerformanceMonitor') as MockMonitor:
+        mock_monitor = Mock()
+        mock_monitor.record_step_time = Mock()
+        MockMonitor.return_value = mock_monitor
+        run_odor_simulation(
+            navigator,
+            video_plume,
+            num_steps=1,
+            record_trajectories=False,
+        )
+        mock_monitor.record_step_time.assert_called()


### PR DESCRIPTION
## Summary
- log step durations and use `record_step_time` for performance tracking
- add `record_step_time` compatibility to odor plume simulation
- add tests ensuring step time recording is invoked

## Testing
- `pytest tests/core/test_performance_monitor_calls.py tests/core/test_simulation_context_run.py::test_run_simulation_sets_results -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0afbd0083209e296900fedd10f9