### PR TITLE
feat: extend simulation results and performance monitoring

### DIFF
--- a/src/odor_plume_nav/core/simulation.py
+++ b/src/odor_plume_nav/core/simulation.py
@@ -180,6 +180,8 @@ class SimulationResults:
         checkpoints: Optional simulation state checkpoints
         visualization_artifacts: Optional visualization outputs
         database_records: Optional database persistence information
+        step_count: Number of simulation steps executed
+        success: Whether the simulation completed successfully
     """
     positions_history: np.ndarray
     orientations_history: np.ndarray
@@ -189,6 +191,8 @@ class SimulationResults:
     checkpoints: List[Dict[str, Any]] = field(default_factory=list)
     visualization_artifacts: Dict[str, Any] = field(default_factory=dict)
     database_records: Dict[str, Any] = field(default_factory=dict)
+    step_count: int = 0
+    success: bool = False
 
 
 class PerformanceMonitor:
@@ -227,32 +231,30 @@ class PerformanceMonitor:
         self.performance_warnings = []
         self.optimization_applied = False
     
-    def record_step(self, step_duration: float) -> None:
-        """Record timing for a simulation step.
-        
-        Parameters
-        ----------
-        step_duration : float
-            Time taken for the step in seconds
-        """
+    def record_step_time(self, step_duration: float) -> None:
+        """Record timing for a simulation step."""
+        logger.debug("Recording step duration", extra={"step_duration": step_duration})
         current_time = time.perf_counter()
-        
+
         # Update counters
         self.total_steps += 1
         self.step_times.append(step_duration)
-        
+
         # Calculate frame time (time since last step)
         frame_time = current_time - self.last_step_time
         self.frame_times.append(frame_time)
         self.last_step_time = current_time
-        
+
         # Maintain rolling history
         if len(self.step_times) > self.history_length:
             self.step_times.pop(0)
             self.frame_times.pop(0)
-        
+
         # Check performance thresholds
         self._check_performance_thresholds()
+
+    # Backward compatibility
+    record_step = record_step_time
     
     def _check_performance_thresholds(self) -> None:
         """Check if performance is below target and record warnings."""
@@ -292,10 +294,10 @@ class PerformanceMonitor:
         recent_frame_time = np.mean(self.frame_times[-5:])
         return 1.0 / recent_frame_time if recent_frame_time > 0 else 0.0
     
-    def get_metrics(self) -> Dict[str, Any]:
+    def get_summary(self) -> Dict[str, Any]:
         """Get comprehensive performance metrics."""
         elapsed_time = time.perf_counter() - self.start_time
-        
+
         metrics = {
             'total_steps': self.total_steps,
             'elapsed_time': elapsed_time,
@@ -305,7 +307,7 @@ class PerformanceMonitor:
             'performance_warnings': len(self.performance_warnings),
             'optimization_applied': self.optimization_applied
         }
-        
+
         if self.step_times:
             metrics.update({
                 'average_step_time': np.mean(self.step_times),
@@ -313,15 +315,19 @@ class PerformanceMonitor:
                 'max_step_time': np.max(self.step_times),
                 'step_time_std': np.std(self.step_times)
             })
-        
+
         if self.frame_times:
             metrics.update({
                 'average_frame_time': np.mean(self.frame_times),
                 'min_frame_time': np.min(self.frame_times),
                 'max_frame_time': np.max(self.frame_times)
             })
-        
+
+        logger.debug("Performance summary computed", extra={"total_steps": self.total_steps})
         return metrics
+
+    # Backward compatibility
+    get_metrics = get_summary
 
 
 @contextlib.contextmanager
@@ -732,7 +738,7 @@ def run_simulation(
                     # Record performance metrics
                     step_duration = time.perf_counter() - step_start_time
                     if performance_monitor is not None:
-                        performance_monitor.record_step(step_duration)
+                        performance_monitor.record_step_time(step_duration)
 
                     # Checkpoint creation
                     if (sim_config.checkpoint_interval > 0 and 
@@ -787,7 +793,7 @@ def run_simulation(
         # Collect performance metrics
         performance_metrics = {}
         if performance_monitor is not None:
-            performance_metrics = performance_monitor.get_metrics()
+            performance_metrics = performance_monitor.get_summary()
 
         # Create metadata
         metadata = {
@@ -816,7 +822,9 @@ def run_simulation(
             metadata=metadata,
             checkpoints=checkpoints,
             visualization_artifacts=visualization_artifacts,
-            database_records=database_records
+            database_records=database_records,
+            step_count=performance_monitor.total_steps if performance_monitor is not None else num_steps,
+            success=True,
         )
 
         sim_logger.info(

--- a/src/odor_plume_nav/tests/test_simulation_extensions.py
+++ b/src/odor_plume_nav/tests/test_simulation_extensions.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from odor_plume_nav.core.controllers import SingleAgentController
+from odor_plume_nav.core import run_simulation, simulation
+from odor_plume_nav.core.simulation import PerformanceMonitor
+
+
+def test_performance_monitor_new_methods_and_aliases():
+    monitor = PerformanceMonitor(target_fps=10.0)
+    monitor.record_step_time(0.01)
+    monitor.record_step(0.02)
+    summary = monitor.get_summary()
+    assert summary["total_steps"] == 2
+    metrics = monitor.get_metrics()
+    assert metrics["total_steps"] == 2
+
+
+def test_run_simulation_populates_results_and_uses_summary(monkeypatch):
+    class DummyMonitor:
+        instances = []
+
+        def __init__(self, *args, **kwargs):
+            self.total_steps = 0
+            self.summary_called = False
+            DummyMonitor.instances.append(self)
+
+        def record_step_time(self, step_duration: float) -> None:
+            self.total_steps += 1
+
+        def record_step(self, step_duration: float) -> None:  # legacy alias should not be used
+            raise AssertionError("record_step should not be used")
+
+        def get_summary(self):
+            self.summary_called = True
+            return {"total_steps": self.total_steps, "sentinel": True}
+
+        def get_metrics(self):
+            raise AssertionError("legacy get_metrics should not be called")
+
+    monkeypatch.setattr(simulation, "PerformanceMonitor", DummyMonitor)
+
+    navigator = SingleAgentController()
+
+    class DummyVideoPlume:
+        frame_count = 10
+        width = 10
+        height = 10
+
+        def get_frame(self, idx):
+            return np.zeros((10, 10), dtype=np.float32)
+
+    results = run_simulation(navigator, DummyVideoPlume(), num_steps=3, dt=1.0)
+
+    assert results.step_count == 3
+    assert results.success is True
+    monitor = DummyMonitor.instances[0]
+    assert monitor.summary_called is True
+    assert results.performance_metrics["sentinel"] is True


### PR DESCRIPTION
## Summary
- track step counts and success status in `SimulationResults`
- expose `record_step_time` and `get_summary` in `PerformanceMonitor` while retaining legacy aliases
- ensure simulation loop calls `record_step_time` for step tracking and leverages summary metrics

## Testing
- `python -m pytest src/odor_plume_nav/tests/test_simulation_extensions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0b0e2208320b4e17bee717ff456