### PR TITLE
feat: summarize simulation results

### DIFF
--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -1078,20 +1078,20 @@ class SimulationContext:
         )
 
         step_count = 0
-        for _ in range(self.config.num_steps):
+        num_steps = self.config.num_steps
+        for _ in range(num_steps):
             if self.performance_monitor is not None:
                 self.performance_monitor.record_step_time(0.001)
             step_count += 1
 
-        success = step_count == self.config.num_steps
         results.step_count = step_count
-        results.success = success
+        results.success = step_count == num_steps
 
         if self.performance_monitor is not None:
             results.performance_metrics = self.performance_monitor.get_summary()
 
-        logger.info(
-            "Simulation completed: steps=%d, success=%s, performance=%s",
+        logging.getLogger(__name__).info(
+            "Simulation completed summary: steps=%d, success=%s, performance=%s",
             results.step_count,
             results.success,
             results.performance_metrics,

--- a/tests/core/test_simulation_context_run.py
+++ b/tests/core/test_simulation_context_run.py
@@ -14,3 +14,13 @@ def test_run_simulation_sets_results(caplog):
     assert results.success is True
     if ctx.performance_monitor is not None:
         assert results.performance_metrics == ctx.performance_monitor.get_summary()
+
+def test_run_simulation_logs_summary(caplog):
+    ctx = SimulationContext.create()
+    ctx.performance_monitor = PerformanceMonitor()
+    with ctx:
+        with caplog.at_level(logging.INFO):
+            ctx.run_simulation(num_steps=3)
+    assert any(
+        "Simulation completed summary" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log simulation summary with step count, success flag, and performance metrics
- test simulation context for summary log emission

## Testing
- `pytest tests/core/test_simulation_context_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57e6af6d48320b13eeef3f70f99e1