### PR TITLE
feat: track simulation completion and performance metrics

### DIFF
--- a/src/odor_plume_nav/core/simulation.py
+++ b/src/odor_plume_nav/core/simulation.py
@@ -231,14 +231,25 @@ class PerformanceMonitor:
         self.performance_warnings = []
         self.optimization_applied = False
     
-    def record_step_time(self, step_duration: float) -> None:
-        """Record timing for a simulation step."""
-        logger.debug("Recording step duration", extra={"step_duration": step_duration})
+    def record_step_time(self, seconds: float, label: str | None = None) -> None:
+        """Record timing for a simulation step.
+
+        Parameters
+        ----------
+        seconds : float
+            Time taken for the step in seconds.
+        label : str | None
+            Optional label for the recorded duration. Currently unused.
+        """
+        logger.debug(
+            "Recording step duration",
+            extra={"step_duration": seconds, "label": label},
+        )
         current_time = time.perf_counter()
 
         # Update counters
         self.total_steps += 1
-        self.step_times.append(step_duration)
+        self.step_times.append(seconds)
 
         # Calculate frame time (time since last step)
         frame_time = current_time - self.last_step_time
@@ -255,17 +266,6 @@ class PerformanceMonitor:
 
     # Backward compatibility
     record_step = record_step_time
-    def record_step_time(self, seconds: float, label: str | None = None) -> None:
-        """Compatibility wrapper accepting durations in seconds.
-
-        Parameters
-        ----------
-        seconds : float
-            Time taken for the step in seconds.
-        label : str | None
-            Optional label for the recorded duration.
-        """
-        self.record_step(seconds)
     
     def _check_performance_thresholds(self) -> None:
         """Check if performance is below target and record warnings."""

--- a/src/odor_plume_nav/tests/test_simulation_extensions.py
+++ b/src/odor_plume_nav/tests/test_simulation_extensions.py
@@ -7,13 +7,23 @@ from odor_plume_nav.core.simulation import PerformanceMonitor
 
 
 def test_performance_monitor_new_methods_and_aliases():
+    """New helper names should function and map to legacy aliases."""
     monitor = PerformanceMonitor(target_fps=10.0)
-    monitor.record_step_time(0.01)
+
+    # record two steps using both the new name and legacy alias
+    monitor.record_step_time(0.01, label="step1")
     monitor.record_step(0.02)
+
+    # summaries should reflect both calls
     summary = monitor.get_summary()
     assert summary["total_steps"] == 2
+
+    # legacy getter should reference the same implementation
     metrics = monitor.get_metrics()
     assert metrics["total_steps"] == 2
+
+    # ensure the alias actually points to the same function object
+    assert PerformanceMonitor.record_step_time is PerformanceMonitor.record_step
 
 
 def test_run_simulation_populates_results_and_uses_summary(monkeypatch):
@@ -25,7 +35,7 @@ def test_run_simulation_populates_results_and_uses_summary(monkeypatch):
             self.summary_called = False
             DummyMonitor.instances.append(self)
 
-        def record_step_time(self, step_duration: float) -> None:
+        def record_step_time(self, step_duration: float, label: str | None = None) -> None:
             self.total_steps += 1
 
         record_step = record_step_time


### PR DESCRIPTION
## Summary
- expose step count and success flags in `SimulationResults`
- consolidate `PerformanceMonitor.record_step_time` and alias `record_step`
- cover new API names in tests and ensure simulations use `get_summary`

## Testing
- `pytest src/odor_plume_nav/tests/test_simulation_extensions.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*


------
https://chatgpt.com/codex/tasks/task_e_68b591bee6148320b4910e0869629957