### PR TITLE
fix(config): remove redundant max_duration validator

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -395,15 +395,6 @@ class SimulationConfig(BaseModel):
             raise ValueError("dt (timestep) must be positive")
         return v
 
-    @field_validator('max_duration')
-    @classmethod
-    def validate_max_duration(cls, v):
-        """Validate that max_duration is positive if provided."""
-        if v is not None and v <= 0:
-            logger.debug("Invalid max_duration: %s", v)
-            raise ValueError("ensure this value is greater than 0")
-        return v
-    
     @field_validator('width', 'height')
     @classmethod
     def validate_dimensions(cls, v):

--- a/tests/config/test_simulation_max_duration.py
+++ b/tests/config/test_simulation_max_duration.py
@@ -9,4 +9,4 @@ def test_max_duration_negative_logs_and_raises(caplog):
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
             SimulationConfig(max_duration=-1)
-    assert "Invalid max_duration" in caplog.text
+    assert "max_duration is not positive" in caplog.text


### PR DESCRIPTION
## Summary
- remove duplicate `max_duration` validator in simulation schema
- align test with updated log message for invalid `max_duration`

## Testing
- `pytest tests/config/test_simulation_max_duration.py::test_max_duration_negative_logs_and_raises -q`
- `pytest tests/config/test_simulation_config_max_duration.py::test_max_duration_must_be_positive_logs_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68b594420fdc8320b391262db98bd705