### PR TITLE
fix(config): ensure utils imports logging

### DIFF
--- a/src/plume_nav_sim/config/utils.py
+++ b/src/plume_nav_sim/config/utils.py
@@ -4,8 +4,8 @@ Configuration utilities for plume_nav_sim.
 This module provides utility functions for configuration validation and management.
 """
 
-import os
 import logging
+import os
 from typing import Dict, Any, Optional, Union, Type
 from pydantic import BaseModel, ValidationError
 


### PR DESCRIPTION
## Summary
- reorder imports so logging is grouped with other standard-library modules

## Testing
- `python -m py_compile src/plume_nav_sim/config/utils.py`
- `python - <<'PY'
import sys
sys.path.append('src')
import plume_nav_sim.config.utils as u
print('loaded', bool(u))
PY`
- `pytest tests/test_config_models.py::TestEnvironmentVariableSupport::test_resolve_env_value -q`
- `pytest tests/config/test_config_utils.py::TestFactoryMethodIntegration::test_create_default_config -q` *(fails: VideoPlumeConfig requires existing video file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5943f7508832083f093733e9d9eb8