### PR TITLE
fix: respect skip flags for video path validation

### DIFF
--- a/tests/test_video_plume_config_video_path.py
+++ b/tests/test_video_plume_config_video_path.py
@@ -32,3 +32,11 @@ def test_base_model_dump_serializes_to_string():
     cfg = VideoPlumeConfig(video_path=path)
     data = BaseModel.model_dump(cfg)
     assert data["video_path"] == "test_video.mp4"
+
+
+@pytest.mark.parametrize("flag_name", ["skip_validation", "_skip_validation"])
+def test_skip_flags_bypass_existence_check(tmp_path, flag_name):
+    """Ensure both skip flags bypass path existence checks."""
+    missing = tmp_path / "missing.mp4"
+    cfg = VideoPlumeConfig(video_path=missing, **{flag_name: True})
+    assert cfg.video_path == missing


### PR DESCRIPTION
## Summary
- allow VideoPlumeConfig to accept `_skip_validation` alias
- skip video path existence checks when either skip flag is true
- add tests for both skip flags

## Testing
- `pytest tests/test_video_plume_config_video_path.py::test_skip_flags_bypass_existence_check tests/test_video_plume_config.py::test_kernel_size_zero_allows_disable_smoothing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59440bf2c8320a6c2d295f4cf7369