### PR TITLE
feat(config): allow skipping video path validation

### DIFF
--- a/tests/test_video_plume_config_video_path.py
+++ b/tests/test_video_plume_config_video_path.py
@@ -38,5 +38,12 @@ def test_base_model_dump_serializes_to_string():
 def test_skip_flags_bypass_existence_check(tmp_path, flag_name):
     """Ensure both skip flags bypass path existence checks."""
     missing = tmp_path / "missing.mp4"
-    cfg = VideoPlumeConfig(video_path=missing, **{flag_name: True})
-    assert cfg.video_path == missing
+    cfg = VideoPlumeConfig(video_path=str(missing), **{flag_name: True})
+    assert cfg.video_path == str(missing)
+
+
+def test_skip_allows_traversal_string():
+    """Skip flag should allow any string, including traversal paths."""
+    traversal = "../nonexistent/../../missing.mp4"
+    cfg = VideoPlumeConfig(video_path=traversal, skip_validation=True)
+    assert cfg.video_path == traversal


### PR DESCRIPTION
## Summary
- allow skipping video path validation and existence checks
- support traversal strings when validation skipped
- expand tests for video path skipping behavior

## Testing
- `pytest tests/test_video_plume_config_video_path.py tests/test_video_plume_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5960e31148320ba775b4899034049