### PR TITLE
refactor(core): remove ActionInterfaceProtocol fallback

### DIFF
--- a/src/plume_nav_sim/core/actions.py
+++ b/src/plume_nav_sim/core/actions.py
@@ -38,58 +38,14 @@ Examples:
 """
 
 from __future__ import annotations
-from typing import Union, Optional, Dict, Any, Tuple, List, TYPE_CHECKING
+from typing import Union, Optional, Dict, Any, Tuple, List
+import logging
 import numpy as np
 
-# Try to import ActionInterfaceProtocol from protocols, define locally if not available
-try:
-    from .protocols import ActionInterfaceProtocol
-except ImportError:
-    # Define ActionInterfaceProtocol locally - this will be moved to protocols.py by another agent
-    from typing import Protocol, runtime_checkable
-    
-    @runtime_checkable
-    class ActionInterfaceProtocol(Protocol):
-        """
-        Protocol defining standardized action processing interface.
-        
-        This protocol ensures consistent action handling across different control
-        modalities while maintaining type safety and framework compatibility.
-        All action interface implementations must provide these core methods.
-        """
-        
-        def translate_action(self, action: Union[int, np.ndarray]) -> Dict[str, Any]:
-            """
-            Translate RL framework action to navigation command.
-            
-            Args:
-                action: Action from RL framework (array for continuous, int for discrete)
-                
-            Returns:
-                Dict[str, Any]: Navigation command dictionary
-            """
-            ...
-        
-        def validate_action(self, action: Union[int, np.ndarray]) -> Union[int, np.ndarray]:
-            """
-            Validate and constrain action to valid range.
-            
-            Args:
-                action: Action to validate
-                
-            Returns:
-                Union[int, np.ndarray]: Validated action
-            """
-            ...
-        
-        def get_action_space(self) -> Optional[spaces.Space]:
-            """
-            Get Gymnasium action space for this interface.
-            
-            Returns:
-                Optional[spaces.Space]: Action space or None if Gymnasium unavailable
-            """
-            ...
+from .protocols import ActionInterfaceProtocol
+
+logger = logging.getLogger(__name__)
+logger.debug("Loaded actions module with ActionInterfaceProtocol from protocols")
 
 # Gymnasium imports for action space construction
 try:

--- a/tests/actions/test_protocol_import.py
+++ b/tests/actions/test_protocol_import.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+import builtins
+import pytest
+
+
+def test_action_interface_protocol_import(monkeypatch):
+    """ActionInterfaceProtocol should import and fail loudly when protocols module is missing."""
+    # successful import should expose ActionInterfaceProtocol from protocols
+    import plume_nav_sim.core.actions as actions
+    assert actions.ActionInterfaceProtocol.__name__ == "ActionInterfaceProtocol"
+
+    # simulate missing protocols module
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.endswith(".protocols"):
+            raise ImportError("protocols module missing")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.core.actions", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.core.actions")


### PR DESCRIPTION
## Summary
- remove inline ActionInterfaceProtocol fallback in actions
- add test ensuring ActionInterfaceProtocol import fails when protocols module missing

## Testing
- `pytest tests/actions/test_protocol_import.py` *(fails: command not found: pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d2a6b848320ae4020e1eaf56cf0