### PR TITLE
refactor: drop BaseSensor fallback in concentration sensor

### DIFF
--- a/src/plume_nav_sim/core/sensors/concentration_sensor.py
+++ b/src/plume_nav_sim/core/sensors/concentration_sensor.py
@@ -70,26 +70,7 @@ import numpy as np
 from plume_nav_sim.protocols.sensor import SensorProtocol
 
 # Base sensor infrastructure
-try:
-    from .base_sensor import BaseSensor
-    BASE_SENSOR_AVAILABLE = True
-except ImportError:
-    # Fallback base class if BaseSensor doesn't exist yet
-    class BaseSensor:
-        def __init__(self, **kwargs):
-            self._enable_logging = kwargs.get('enable_logging', True)
-            self._sensor_id = kwargs.get('sensor_id', f"sensor_{id(self)}")
-            self._performance_metrics = {
-                'measurement_times': [],
-                'total_measurements': 0,
-                'noise_samples': 0,
-                'drift_updates': 0
-            }
-        
-        def get_performance_metrics(self) -> Dict[str, Any]:
-            return self._performance_metrics.copy()
-    
-    BASE_SENSOR_AVAILABLE = False
+from .base_sensor import BaseSensor
 
 # Logging integration
 try:
@@ -403,7 +384,7 @@ class ConcentrationSensor(BaseSensor):
         })
         
         # Log sensor initialization
-        if self._enable_logging and BASE_SENSOR_AVAILABLE:
+        if self._enable_logging:
             if LOGURU_AVAILABLE:
                 logger.bind(
                     sensor_type="ConcentrationSensor",

--- a/tests/sensors/test_base_sensor_import.py
+++ b/tests/sensors/test_base_sensor_import.py
@@ -1,0 +1,31 @@
+import importlib
+import importlib.machinery
+import sys
+import pytest
+
+
+def test_base_sensor_import(monkeypatch):
+    """BaseSensor import should fail loudly when the module is missing."""
+    # Import succeeds when module is available
+    module = importlib.import_module('plume_nav_sim.core.sensors.base_sensor')
+    assert module is not None
+
+    real_find_spec = importlib.machinery.PathFinder.find_spec
+
+    def fake_find_spec(name, path=None, target=None):
+        if name == 'plume_nav_sim.core.sensors.base_sensor':
+            return None
+        return real_find_spec(name, path, target)
+
+    # Remove access to base_sensor
+    monkeypatch.setattr(importlib.machinery.PathFinder, 'find_spec', fake_find_spec)
+    monkeypatch.delitem(sys.modules, 'plume_nav_sim.core.sensors.base_sensor', raising=False)
+    monkeypatch.delitem(sys.modules, 'plume_nav_sim.core.sensors.concentration_sensor', raising=False)
+
+    # Direct import now fails
+    with pytest.raises(ImportError):
+        importlib.import_module('plume_nav_sim.core.sensors.base_sensor')
+
+    # Dependent modules should also fail to import
+    with pytest.raises(ImportError):
+        importlib.import_module('plume_nav_sim.core.sensors.concentration_sensor')


### PR DESCRIPTION
## Summary
- add test to ensure BaseSensor import errors propagate
- remove BaseSensor fallback from concentration sensor

## Testing
- `pytest tests/sensors/test_base_sensor_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59d27e6188320b8a499583d3639a4