### PR TITLE
fix: raise error when sensor schemas missing

### DIFF
--- a/src/plume_nav_sim/core/sensors/base_sensor.py
+++ b/src/plume_nav_sim/core/sensors/base_sensor.py
@@ -98,16 +98,18 @@ except ImportError:
     logger = logging.getLogger(__name__)
     LOGURU_AVAILABLE = False
 
-# Configuration schemas - handle case where they don't exist yet
+# Configuration schemas - fail fast when they are missing
 try:
     from ...config.schemas import SensorConfig, BinarySensorConfig, ConcentrationSensorConfig
     SCHEMAS_AVAILABLE = True
-except ImportError:
-    # These will be created by other agents - use minimal fallback types
-    SensorConfig = Dict[str, Any]
-    BinarySensorConfig = Dict[str, Any] 
-    ConcentrationSensorConfig = Dict[str, Any]
-    SCHEMAS_AVAILABLE = False
+except ImportError as exc:  # pragma: no cover - executed only when schemas are absent
+    logger.error(
+        "Configuration schemas could not be imported: %s", exc
+    )
+    raise ImportError(
+        "Required configuration schemas are missing. Ensure ``plume_nav_sim.config.schemas`` "
+        "defines `SensorConfig`, `BinarySensorConfig`, and `ConcentrationSensorConfig`."
+    ) from exc
 
 # PSUtil for memory monitoring (optional dependency)
 try:

--- a/tests/sensors/test_config_schema_presence.py
+++ b/tests/sensors/test_config_schema_presence.py
@@ -1,0 +1,19 @@
+import builtins
+import pytest
+
+
+def test_sensor_config_import_and_missing(monkeypatch):
+    # Import should succeed when module is present
+    from plume_nav_sim.config.schemas import SensorConfig  # noqa: F401
+
+    original_import = builtins.__import__
+
+    def mocked_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.config.schemas":
+            raise ImportError("Mocked missing module")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
+
+    with pytest.raises(ImportError):
+        from plume_nav_sim.config.schemas import SensorConfig  # noqa: F401


### PR DESCRIPTION
## Summary
- test sensor config schema presence
- raise import error when sensor schemas missing

## Testing
- `pytest tests/sensors/test_config_schema_presence.py -q` *(fails: ImportError: cannot import name 'SensorConfig')*

------
https://chatgpt.com/codex/tasks/task_e_68b59d1f73288320960c20605d8c1953