### PR TITLE
fix: require gymnasium dependency

### DIFF
--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -90,19 +90,17 @@ from pathlib import Path
 import logging
 import numpy as np
 
-# Gymnasium imports with fallback compatibility
+# Gymnasium imports are required; fail fast with guidance if missing
 try:
     import gymnasium as gym
     from gymnasium.spaces import Box, Dict as DictSpace
     from gymnasium.error import DependencyNotInstalled
-    GYMNASIUM_AVAILABLE = True
-except ImportError:
-    GYMNASIUM_AVAILABLE = False
-    # Create mock classes to prevent import errors during transition
-    class gym:
-        class Env:
-            def __init__(self): pass
-    Box = DictSpace = None
+except ImportError as exc:
+    raise ImportError(
+        "Gymnasium is required for plume_nav_sim. Install with `pip install gymnasium`."
+    ) from exc
+
+GYMNASIUM_AVAILABLE = True
 
 # Core plume navigation imports with graceful fallbacks during migration
 try:

--- a/src/plume_nav_sim/tests/test_gymnasium_dependency.py
+++ b/src/plume_nav_sim/tests/test_gymnasium_dependency.py
@@ -1,0 +1,18 @@
+"""Tests that PlumeNavigationEnv hard depends on gymnasium."""
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_import_fails_without_gymnasium(monkeypatch):
+    """Importing PlumeNavigationEnv should raise ImportError when gymnasium is missing."""
+    # Remove gymnasium modules to simulate the dependency being absent
+    for mod in [m for m in list(sys.modules) if m.startswith("gymnasium")]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.setitem(sys.modules, "gymnasium", None)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.envs.plume_navigation_env", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.envs.plume_navigation_env")


### PR DESCRIPTION
## Summary
- enforce gymnasium requirement with explicit ImportError guidance
- add test confirming PlumeNavigationEnv fails without gymnasium

## Testing
- `pytest src/plume_nav_sim/tests/test_gymnasium_dependency.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d037ffc8320861d6d72436a7408