### PR TITLE
feat: enforce direct protocol import

### DIFF
--- a/src/plume_nav_sim/core/initialization.py
+++ b/src/plume_nav_sim/core/initialization.py
@@ -45,84 +45,18 @@ Authors: Blitzy Platform v1.0 Development Team
 
 from __future__ import annotations
 import numpy as np
-from typing import Union, Optional, Dict, Any, List, Tuple, Protocol, runtime_checkable
+from typing import Union, Optional, Dict, Any, List, Tuple
 from dataclasses import dataclass
 import pandas as pd
 from pathlib import Path
 import warnings
+import logging
 
-# Import the protocol from the protocols module once it's defined
-# For now, we'll define it locally as per the schema requirements
-try:
-    from .protocols import AgentInitializerProtocol
-except ImportError:
-    # Define the protocol locally since it may not exist yet in protocols.py
-    @runtime_checkable
-    class AgentInitializerProtocol(Protocol):
-        """
-        Protocol defining the interface for agent initialization strategies.
-        
-        This protocol ensures consistent initialization behavior across different
-        strategies while maintaining type safety and extensibility. All concrete
-        initialization strategies must implement these core methods.
-        
-        The protocol supports deterministic seeding, domain validation, and
-        flexible position generation for diverse experimental requirements.
-        """
-        
-        def initialize_positions(
-            self, 
-            num_agents: int, 
-            **kwargs: Any
-        ) -> np.ndarray:
-            """
-            Generate initial agent positions based on strategy configuration.
-            
-            Args:
-                num_agents: Number of agents to initialize
-                **kwargs: Additional strategy-specific parameters
-                
-            Returns:
-                np.ndarray: Agent positions with shape (num_agents, 2)
-                    Each row contains [x, y] coordinates for one agent
-                    
-            Notes:
-                - Must be deterministic when seeded
-                - Positions should be within domain bounds
-                - Performance target: <1ms for 100 agents
-            """
-            ...
-        
-        def validate_domain(self, positions: np.ndarray) -> bool:
-            """
-            Validate that generated positions comply with domain constraints.
-            
-            Args:
-                positions: Agent positions to validate with shape (n_agents, 2)
-                
-            Returns:
-                bool: True if all positions are valid, False otherwise
-                
-            Notes:
-                - Checks domain bounds compliance
-                - No collision detection required per specification
-                - Should be called after position generation
-            """
-            ...
-        
-        def reset(self, seed: Optional[int] = None) -> None:
-            """
-            Reset initializer state with optional deterministic seeding.
-            
-            Args:
-                seed: Random seed for deterministic behavior (optional)
-                
-            Notes:
-                - Reinitializes internal random state
-                - Ensures reproducible position generation
-                - Should be called before each episode
-            """
-            ...
+logger = logging.getLogger(__name__)
+
+from .protocols import AgentInitializerProtocol
+
+logger.info("AgentInitializerProtocol import succeeded")
 
 
 @dataclass

--- a/src/plume_nav_sim/tests/test_initialization_import.py
+++ b/src/plume_nav_sim/tests/test_initialization_import.py
@@ -1,0 +1,40 @@
+import importlib
+import logging
+import builtins
+import sys
+import types
+
+import pytest
+
+
+def test_agent_initializer_protocol_import_logs_success(caplog, monkeypatch):
+    # Provide minimal pandas stub to satisfy import
+    monkeypatch.setitem(sys.modules, 'pandas', types.ModuleType('pandas'))
+
+    caplog.set_level(logging.INFO)
+    import plume_nav_sim.core.initialization as init
+    importlib.reload(init)
+    assert "AgentInitializerProtocol import succeeded" in caplog.text
+
+
+def test_missing_protocols_raises_import_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'pandas', types.ModuleType('pandas'))
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        target = "plume_nav_sim.core.protocols"
+        pkg = globals.get("__package__") if globals else None
+        if name == target or (level and name == "protocols" and pkg == "plume_nav_sim.core"):
+            raise ModuleNotFoundError(f"No module named '{target}'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("plume_nav_sim.core.protocols", None)
+    sys.modules.pop("plume_nav_sim.core.initialization", None)
+    core_pkg = sys.modules.get("plume_nav_sim.core")
+    if core_pkg and hasattr(core_pkg, "protocols"):
+        delattr(core_pkg, "protocols")
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("plume_nav_sim.core.initialization")


### PR DESCRIPTION
## Summary
- use direct AgentInitializerProtocol import with success logging
- add tests ensuring import logging and clear failure when protocol module missing

## Testing
- `pytest src/plume_nav_sim/tests/test_initialization_import.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*

------
https://chatgpt.com/codex/tasks/task_e_68b59f0d914083209bee36bb8630f596