### PR TITLE
feat(utils): require SourceProtocol for visualization

### DIFF
--- a/src/plume_nav_sim/utils/visualization.py
+++ b/src/plume_nav_sim/utils/visualization.py
@@ -50,19 +50,30 @@ from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
 from matplotlib.colors import ListedColormap
 
+# Initialize module logger with fallback
+try:
+    from plume_nav_sim.utils.logging_setup import get_module_logger
+    logger = get_module_logger(__name__)
+except ImportError:
+    # Fallback logging implementation
+    import logging
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
 # Import new protocols for enhanced visualization capabilities
 try:
     from ..core.protocols import SourceProtocol
-    PROTOCOLS_AVAILABLE = True
-except ImportError:
-    # Fallback for development when protocols might not be available yet
-    class SourceProtocol:
-        """Fallback protocol definition for development."""
-        def get_position(self) -> Tuple[float, float]:
-            return (0.0, 0.0)
-        def get_emission_rate(self) -> float:
-            return 0.0
-    PROTOCOLS_AVAILABLE = False
+    logger.info("Successfully imported SourceProtocol")
+except ImportError as exc:
+    logger.exception("Failed to import SourceProtocol")
+    raise
 
 # Optional GUI dependencies for debug visualizer
 try:
@@ -98,23 +109,6 @@ except ImportError:
     # Fallback types for environments without Hydra
     DictConfig = dict
     OmegaConf = None
-
-# Initialize module logger with fallback
-try:
-    from plume_nav_sim.utils.logging_setup import get_module_logger
-    logger = get_module_logger(__name__)
-except ImportError:
-    # Fallback logging implementation
-    import logging
-    logger = logging.getLogger(__name__)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
 
 
 @runtime_checkable

--- a/tests/visualization/test_source_protocol_import.py
+++ b/tests/visualization/test_source_protocol_import.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import types
+
+import pytest
+import io
+import logging
+
+
+def test_source_protocol_import_logs_success(monkeypatch):
+    """Visualization module should log successful SourceProtocol import."""
+    stream = io.StringIO()
+
+    def fake_get_module_logger(name):
+        logger = logging.getLogger(name)
+        handler = logging.StreamHandler(stream)
+        logger.handlers = [handler]
+        logger.setLevel(logging.INFO)
+        return logger
+
+    import plume_nav_sim.utils.logging_setup as logging_setup
+    monkeypatch.setattr(logging_setup, 'get_module_logger', fake_get_module_logger)
+
+    monkeypatch.delitem(sys.modules, 'plume_nav_sim.utils.visualization', raising=False)
+    importlib.import_module('plume_nav_sim.utils.visualization')
+    assert "Successfully imported SourceProtocol" in stream.getvalue()
+
+
+def test_source_protocol_import_error_propagated(monkeypatch):
+    """Visualization module should propagate ImportError when SourceProtocol is missing."""
+    monkeypatch.delitem(sys.modules, 'plume_nav_sim.utils.visualization', raising=False)
+    dummy_module = types.ModuleType('plume_nav_sim.core.protocols')
+    monkeypatch.setitem(sys.modules, 'plume_nav_sim.core.protocols', dummy_module)
+    with pytest.raises(ImportError):
+        importlib.import_module('plume_nav_sim.utils.visualization')


### PR DESCRIPTION
## Summary
- log successful SourceProtocol import in visualization utils
- drop fallback SourceProtocol definition and raise on missing import
- add tests for logging and ImportError propagation

## Testing
- `pytest tests/visualization/test_source_protocol_import.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*

------
https://chatgpt.com/codex/tasks/task_e_68b59f0ee70483208e1441b4fd4eeaa6