### PR TITLE
fix: raise ImportError when protocol interfaces unavailable

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -252,22 +252,14 @@ except ImportError:
     _core_navigation_available = False
 
 # New v1.0 protocol interfaces for pluggable architecture
-try:
-    from plume_nav_sim.core.protocols import (
-        SourceProtocol,
-        BoundaryPolicyProtocol,
-        ActionInterfaceProtocol,
-        RecorderProtocol,
-        StatsAggregatorProtocol
-    )
-    _v1_protocols_available = True
-except ImportError:
-    SourceProtocol = None
-    BoundaryPolicyProtocol = None
-    ActionInterfaceProtocol = None
-    RecorderProtocol = None
-    StatsAggregatorProtocol = None
-    _v1_protocols_available = False
+from plume_nav_sim.core.protocols import (
+    SourceProtocol,
+    BoundaryPolicyProtocol,
+    ActionInterfaceProtocol,
+    RecorderProtocol,
+    StatsAggregatorProtocol,
+)
+_v1_protocols_available = True
 
 # Environment components
 try:

--- a/tests/test_protocol_import_error.py
+++ b/tests/test_protocol_import_error.py
@@ -1,0 +1,23 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_missing_protocols_module_raises_import_error(monkeypatch):
+    """Package import should fail when protocol module is missing."""
+    sys.modules.pop("plume_nav_sim", None)
+    sys.modules.pop("plume_nav_sim.core.protocols", None)
+
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.core.protocols":
+            raise ImportError("mock missing protocol module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim")


### PR DESCRIPTION
## Summary
- import core protocol interfaces directly
- fail fast when protocol module is missing and test the behavior

## Testing
- `pytest tests/test_protocol_import_error.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*
- `pip install pyarrow -q` *(fails: Could not find a version that satisfies the requirement pyarrow)*

------
https://chatgpt.com/codex/tasks/task_e_68b59f66e6688320ba5ecd6b409c4c9e