### PR TITLE
fix(envs): enforce protocol import failures

### DIFF
--- a/src/plume_nav_sim/envs/__init__.py
+++ b/src/plume_nav_sim/envs/__init__.py
@@ -282,74 +282,61 @@ except ImportError as e:
     ) if LOGGING_AVAILABLE else None
 
 # Import modular component protocols for pluggable architecture
-try:
-    from plume_nav_sim.core.protocols import (
-        PlumeModelProtocol,
-        WindFieldProtocol,
-        SensorProtocol,
-        AgentObservationProtocol,
-        AgentActionProtocol,
-        NavigatorFactory,
-        # New v1.0 protocols for protocol-based architecture
-        SourceProtocol,
-        BoundaryPolicyProtocol,
-        ActionInterfaceProtocol,
-        RecorderProtocol,
-        StatsAggregatorProtocol,
-        AgentInitializerProtocol
-    )
-    __all__.extend([
-        "PlumeModelProtocol",
-        "WindFieldProtocol",
-        "SensorProtocol",
-        "AgentObservationProtocol", 
-        "AgentActionProtocol",
-        "NavigatorFactory",
-        # New v1.0 protocol interfaces
-        "SourceProtocol",
-        "BoundaryPolicyProtocol", 
-        "ActionInterfaceProtocol",
-        "RecorderProtocol",
-        "StatsAggregatorProtocol",
-        "AgentInitializerProtocol"
-    ])
-    PROTOCOLS_AVAILABLE = True
-    NEW_PROTOCOLS_AVAILABLE = True
-    logger.info(
-        "Enhanced modular component protocols available for v1.0 architecture",
-        extra={
-            "metric_type": "environment_capability",
-            "component": "protocols",
-            "protocols": ["plume_model", "wind_field", "sensor", "observation", "action", 
-                         "source", "boundary_policy", "action_interface", "recorder", "stats_aggregator", "agent_initializer"],
-            "v1_architecture": True
-        }
-    ) if LOGGING_AVAILABLE else None
-except ImportError as e:
-    PlumeModelProtocol = None
-    WindFieldProtocol = None
-    SensorProtocol = None
-    AgentObservationProtocol = None
-    AgentActionProtocol = None
-    NavigatorFactory = None
-    # New v1.0 protocols
-    SourceProtocol = None
-    BoundaryPolicyProtocol = None
-    ActionInterfaceProtocol = None
-    RecorderProtocol = None
-    StatsAggregatorProtocol = None
-    AgentInitializerProtocol = None
-    PROTOCOLS_AVAILABLE = False
-    NEW_PROTOCOLS_AVAILABLE = False
-    logger.warning(
-        f"Enhanced modular component protocols not available: {e}",
-        extra={
-            "metric_type": "environment_limitation",
-            "missing_component": "protocols",
-            "error": str(e),
-            "note": "v1.0 protocol-based architecture features disabled"
-        }
-    ) if LOGGING_AVAILABLE else None
+from plume_nav_sim.core.protocols import (
+    PlumeModelProtocol,
+    WindFieldProtocol,
+    SensorProtocol,
+    AgentObservationProtocol,
+    AgentActionProtocol,
+    NavigatorFactory,
+    # New v1.0 protocols for protocol-based architecture
+    SourceProtocol,
+    BoundaryPolicyProtocol,
+    ActionInterfaceProtocol,
+    RecorderProtocol,
+    StatsAggregatorProtocol,
+    AgentInitializerProtocol,
+)
+
+__all__.extend([
+    "PlumeModelProtocol",
+    "WindFieldProtocol",
+    "SensorProtocol",
+    "AgentObservationProtocol",
+    "AgentActionProtocol",
+    "NavigatorFactory",
+    # New v1.0 protocol interfaces
+    "SourceProtocol",
+    "BoundaryPolicyProtocol",
+    "ActionInterfaceProtocol",
+    "RecorderProtocol",
+    "StatsAggregatorProtocol",
+    "AgentInitializerProtocol",
+])
+
+PROTOCOLS_AVAILABLE = True
+NEW_PROTOCOLS_AVAILABLE = True
+logger.info(
+    "Enhanced modular component protocols available for v1.0 architecture",
+    extra={
+        "metric_type": "environment_capability",
+        "component": "protocols",
+        "protocols": [
+            "plume_model",
+            "wind_field",
+            "sensor",
+            "observation",
+            "action",
+            "source",
+            "boundary_policy",
+            "action_interface",
+            "recorder",
+            "stats_aggregator",
+            "agent_initializer",
+        ],
+        "v1_architecture": True,
+    },
+) if LOGGING_AVAILABLE else None
 
 # Import plume model implementations
 try:

--- a/tests/test_envs_missing_protocols.py
+++ b/tests/test_envs_missing_protocols.py
@@ -1,0 +1,21 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_envs_import_raises_when_protocols_missing(monkeypatch):
+    """Env package should fail to import when core protocols are missing."""
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.core.protocols":
+            raise ImportError("protocols missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.envs", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.envs")


### PR DESCRIPTION
## Summary
- remove silent fallbacks when importing core protocols in envs and import them directly
- add regression test ensuring env package fails to import if protocols are missing

## Testing
- `pytest tests/test_envs_missing_protocols.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'Table')*


------
https://chatgpt.com/codex/tasks/task_e_68b59f673674832094a58d0eab2a57e5