### PR TITLE
enforce core protocol imports in plume navigation env

### DIFF
--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -104,37 +104,18 @@ except ImportError:
             def __init__(self): pass
     Box = DictSpace = None
 
-# Core plume navigation imports with graceful fallbacks during migration
-try:
-    from plume_nav_sim.core.protocols import (
-        NavigatorProtocol, NavigatorFactory, PlumeModelProtocol, 
-        WindFieldProtocol, SensorProtocol, AgentObservationProtocol, 
-        AgentActionProtocol, AgentInitializerProtocol
-    )
-    NAVIGATOR_AVAILABLE = True
-except ImportError:
-    # Fallback during migration - will be created by other agents
-    NavigatorProtocol = Any
-    PlumeModelProtocol = Any
-    WindFieldProtocol = Any
-    SensorProtocol = Any
-    AgentObservationProtocol = Any
-    AgentActionProtocol = Any
-    AgentInitializerProtocol = Any
-    class NavigatorFactory:
-        @staticmethod
-        def single_agent(**kwargs):
-            raise ImportError("NavigatorFactory not yet available")
-        @staticmethod
-        def create_plume_model(**kwargs):
-            raise ImportError("PlumeModel creation not yet available")
-        @staticmethod
-        def create_wind_field(**kwargs):
-            raise ImportError("WindField creation not yet available")
-        @staticmethod
-        def create_sensors(**kwargs):
-            raise ImportError("Sensor creation not yet available")
-    NAVIGATOR_AVAILABLE = False
+# Core plume navigation imports
+from plume_nav_sim.core.protocols import (
+    NavigatorProtocol,
+    NavigatorFactory,
+    PlumeModelProtocol,
+    WindFieldProtocol,
+    SensorProtocol,
+    AgentObservationProtocol,
+    AgentActionProtocol,
+    AgentInitializerProtocol,
+)
+NAVIGATOR_AVAILABLE = True
 
 # Enhanced space definitions with proper Gymnasium compliance
 try:

--- a/tests/envs/test_core_protocols_import.py
+++ b/tests/envs/test_core_protocols_import.py
@@ -1,0 +1,19 @@
+import importlib
+import builtins
+import sys
+import pytest
+
+
+def test_import_error_when_core_protocols_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.core.protocols":
+            raise ImportError("protocols missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.envs.plume_navigation_env", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.envs.plume_navigation_env")


### PR DESCRIPTION
## Summary
- import core navigator protocols directly, remove Any fallbacks
- ensure missing protocol modules raise ImportError
- add test verifying ImportError when protocols are unavailable

## Testing
- `pytest tests/envs/test_core_protocols_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59f6cb1ac83209e567510ee332041