### PR TITLE
fix(cli): fail fast when Hydra missing

### DIFF
--- a/src/plume_nav_sim/cli/main.py
+++ b/src/plume_nav_sim/cli/main.py
@@ -71,13 +71,13 @@ try:
     from hydra.core.global_hydra import GlobalHydra
     from hydra.core.hydra_config import HydraConfig
     from omegaconf import DictConfig, OmegaConf, ListConfig
-    HYDRA_AVAILABLE = True
-except ImportError:
-    HYDRA_AVAILABLE = False
-    warnings.warn(
-        "Hydra not available. Advanced configuration features will be limited.",
-        ImportWarning
-    )
+except ImportError as exc:  # pragma: no cover - dependency required for CLI
+    logger.error("Hydra is required for plume_nav_sim CLI. Install hydra-core.")
+    raise ImportError(
+        "Hydra is required for plume_nav_sim CLI. Install hydra-core."
+    ) from exc
+
+HYDRA_AVAILABLE = True
 
 # Import core system components
 from plume_nav_sim.api.navigation import (

--- a/tests/cli/test_missing_hydra.py
+++ b/tests/cli/test_missing_hydra.py
@@ -1,0 +1,20 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+def test_import_error_when_hydra_missing(monkeypatch):
+    """Importing CLI main should fail if Hydra is absent."""
+    monkeypatch.setitem(sys.modules, "hydra", None)
+
+    path = pathlib.Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim" / "cli" / "main.py"
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.cli.main", path)
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ImportError) as exc:
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    assert "hydra" in str(exc.value).lower()


### PR DESCRIPTION
## Summary
- raise clear error when Hydra isn't installed and CLI is imported
- test that importing CLI without Hydra fails with ImportError

## Testing
- `pytest tests/cli/test_missing_hydra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bba2c1c083209152b3961d038826