### PR TITLE
refactor(debug): require PySide6 for GUI

### DIFF
--- a/tests/debug/test_gui_import.py
+++ b/tests/debug/test_gui_import.py
@@ -1,0 +1,23 @@
+import importlib
+import builtins
+import sys
+
+import pytest
+
+
+def test_import_requires_pyside6(monkeypatch):
+    """Debug GUI import should raise ImportError when PySide6 is unavailable."""
+    monkeypatch.delitem(sys.modules, "PySide6", raising=False)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.debug.gui", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("PySide6"):
+            raise ImportError("PySide6 not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.debug.gui")


### PR DESCRIPTION
## Summary
- remove PySide6 mock fallbacks and require real PySide6 at import
- add unit test asserting ImportError when PySide6 is missing

## Testing
- `pytest tests/debug/test_gui_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bba4f77c8320883c706c2edd9b1a