### PR TITLE
refactor(db): require SQLAlchemy at import time

### DIFF
--- a/src/plume_nav_sim/db/__init__.py
+++ b/src/plume_nav_sim/db/__init__.py
@@ -28,9 +28,6 @@ from .session import (
     is_database_enabled,
     test_async_database_connection,
     test_database_connection,
-    DOTENV_AVAILABLE,
-    HYDRA_AVAILABLE,
-    SQLALCHEMY_AVAILABLE,
 )
 
 __all__ = [
@@ -46,7 +43,4 @@ __all__ = [
     "is_database_enabled",
     "test_async_database_connection",
     "test_database_connection",
-    "DOTENV_AVAILABLE",
-    "HYDRA_AVAILABLE", 
-    "SQLALCHEMY_AVAILABLE",
 ]

--- a/tests/db/test_session_imports.py
+++ b/tests/db/test_session_imports.py
@@ -1,0 +1,26 @@
+import builtins
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+def test_session_import_raises_without_sqlalchemy(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'sqlalchemy', raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith('sqlalchemy'):
+            raise ImportError('No module named sqlalchemy')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+    session_path = pathlib.Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'db' / 'session.py'
+    spec = importlib.util.spec_from_file_location('session', session_path)
+    with pytest.raises(ImportError, match="sqlalchemy"):
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- import SQLAlchemy, Hydra, and dotenv at module load and log missing deps
- drop optional dependency flags and simplify database enablement check
- add regression test for missing SQLAlchemy dependency

## Testing
- `pytest tests/db/test_session_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5bba814348320836903e255f5369f