### PR TITLE
fix: require Hydra for analysis module

### DIFF
--- a/src/plume_nav_sim/analysis/__init__.py
+++ b/src/plume_nav_sim/analysis/__init__.py
@@ -96,22 +96,17 @@ from .stats import (
 # Recording system integration
 from ..recording import RecorderFactory
 
-# Hydra configuration support
+# Configure module logging
+logger = logging.getLogger(__name__)
+
+# Hydra configuration support (fail fast if unavailable)
 try:
     from hydra import instantiate
     from omegaconf import DictConfig
     HYDRA_AVAILABLE = True
-except ImportError:
-    # Fallback for environments without Hydra
-    def instantiate(config, **kwargs):
-        """Fallback instantiate function when Hydra is not available."""
-        raise ImportError("Hydra is required for configuration-driven instantiation")
-    
-    DictConfig = dict
-    HYDRA_AVAILABLE = False
-
-# Configure module logging
-logger = logging.getLogger(__name__)
+except ImportError as e:  # pragma: no cover - executed when Hydra is missing
+    logger.error("Hydra is required for configuration-driven analysis: %s", e)
+    raise
 
 # Module version for API compatibility tracking
 __version__ = "1.0.0"

--- a/tests/analysis/test_hydra_required.py
+++ b/tests/analysis/test_hydra_required.py
@@ -1,0 +1,38 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import pytest
+
+
+def test_hydra_required():
+    package_root = pathlib.Path(__file__).resolve().parents[2] / "src/plume_nav_sim"
+    pkg = types.ModuleType("plume_nav_sim")
+    pkg.__path__ = [str(package_root)]
+    sys.modules.setdefault("plume_nav_sim", pkg)
+
+    # stub dependencies required by analysis module
+    sys.modules.setdefault("plume_nav_sim.recording", types.ModuleType("plume_nav_sim.recording")).RecorderFactory = object
+    core_mod = types.ModuleType("plume_nav_sim.core")
+    protocols_mod = types.ModuleType("plume_nav_sim.core.protocols")
+    protocols_mod.StatsAggregatorProtocol = object
+    core_mod.protocols = protocols_mod
+    sys.modules.setdefault("plume_nav_sim.core", core_mod)
+    sys.modules.setdefault("plume_nav_sim.core.protocols", protocols_mod)
+
+    stats_mod = types.ModuleType("plume_nav_sim.analysis.stats")
+    stats_mod.StatsAggregator = object
+    stats_mod.StatsAggregatorConfig = object
+    stats_mod.calculate_basic_stats = object
+    stats_mod.calculate_advanced_stats = object
+    stats_mod.create_stats_aggregator = object
+    stats_mod.generate_summary_report = object
+    sys.modules.setdefault("plume_nav_sim.analysis.stats", stats_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "plume_nav_sim.analysis", package_root / "analysis" / "__init__.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    with pytest.raises(ImportError) as excinfo:
+        spec.loader.exec_module(module)
+    assert "hydra" in str(excinfo.value).lower()


### PR DESCRIPTION
## Summary
- log and fail fast when Hydra is unavailable in analysis package
- add test ensuring analysis module raises ImportError if Hydra is missing

## Testing
- `pytest tests/analysis/test_hydra_required.py -q --confcutdir=tests/analysis`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbacd4ac8320bc3bf15ffccaa06b