### PR TITLE
refactor: enforce strict visualization dependencies

### DIFF
--- a/tests/utils/test_visualization_imports.py
+++ b/tests/utils/test_visualization_imports.py
@@ -1,0 +1,31 @@
+"""Tests for ensuring visualization module fails fast when dependencies are missing."""
+
+import importlib
+import builtins
+import sys
+
+import pytest
+
+MODULE_PATH = "plume_nav_sim.utils.visualization"
+
+@pytest.mark.parametrize("missing_module", [
+    "plume_nav_sim.utils.logging_setup",
+    "PySide6",
+    "streamlit",
+    "hydra.core.config_store",
+])
+def test_import_fails_when_dependency_missing(monkeypatch, missing_module):
+    """Visualization imports should raise ImportError when dependencies are missing."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == missing_module or name.startswith(missing_module + "."):
+            raise ImportError(f"No module named {missing_module}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop(MODULE_PATH, None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(MODULE_PATH)


### PR DESCRIPTION
## Summary
- test visualization import behavior when dependencies are missing
- refactor visualization utility to fail fast if logging setup, PySide6, Streamlit, or Hydra are unavailable

## Testing
- `pytest tests/utils/test_visualization_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbb6576c832094902f44d18ef9c1