### PR TITLE
refactor: require hydra for protocols module

### DIFF
--- a/src/odor_plume_nav/core/protocols.py
+++ b/src/odor_plume_nav/core/protocols.py
@@ -16,15 +16,20 @@ from __future__ import annotations
 from typing import Protocol, Union, Optional, Tuple, List, Any, runtime_checkable
 from typing_extensions import Self
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Hydra imports for configuration integration
 try:
     from omegaconf import DictConfig
     HYDRA_AVAILABLE = True
-except ImportError:
-    # Fallback for environments without Hydra
-    DictConfig = dict
+except ImportError as exc:  # pragma: no cover - import error path
     HYDRA_AVAILABLE = False
+    logger.exception(
+        "Hydra is required for odor_plume_nav.core.protocols; install omegaconf to enable configuration support"
+    )
+    raise
 
 # Import configuration schemas for type hints
 from odor_plume_nav.domain.models import NavigatorConfig, SingleAgentConfig, MultiAgentConfig

--- a/tests/core/test_protocol_hydra_dependency.py
+++ b/tests/core/test_protocol_hydra_dependency.py
@@ -1,0 +1,22 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_protocol_import_requires_hydra(monkeypatch):
+    """Protocols module should raise ImportError when Hydra (omegaconf) is missing."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "omegaconf" or name.startswith("omegaconf."):
+            raise ImportError("No module named 'omegaconf'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "odor_plume_nav.core.protocols", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("odor_plume_nav.core.protocols")


### PR DESCRIPTION
## Summary
- require Hydra for `odor_plume_nav.core.protocols` and log missing dependency
- add regression test ensuring protocols import fails without Hydra

## Testing
- `./setup_env.sh --dev` *(fails: No such file or directory)*
- `pytest tests/core/test_protocol_hydra_dependency.py`


------
https://chatgpt.com/codex/tasks/task_e_68b62bd93b2c8320a8e6fa031e844fee