### PR TITLE
refactor: enforce mandatory hydra and dotenv imports

### DIFF
--- a/tests/config/test_missing_hydra_dotenv.py
+++ b/tests/config/test_missing_hydra_dotenv.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import builtins
+
+import pytest
+
+
+def _assert_import_error(monkeypatch, missing_module: str) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith(missing_module):
+            raise ModuleNotFoundError(f"No module named '{missing_module}'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("odor_plume_nav.config", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("odor_plume_nav.config")
+
+
+def test_missing_hydra(monkeypatch):
+    _assert_import_error(monkeypatch, "hydra")
+
+
+def test_missing_dotenv(monkeypatch):
+    _assert_import_error(monkeypatch, "dotenv")


### PR DESCRIPTION
## Summary
- add tests for missing hydra and dotenv modules
- require hydra and python-dotenv during config import and log errors on failure

## Testing
- `pytest tests/config/test_missing_hydra_dotenv.py`

------
https://chatgpt.com/codex/tasks/task_e_68b62bd4af2c8320bb778af8632376e3