### PR TITLE
refactor: remove sb3 fallback from policies

### DIFF
--- a/src/odor_plume_nav/rl/policies.py
+++ b/src/odor_plume_nav/rl/policies.py
@@ -42,17 +42,10 @@ try:
     from stable_baselines3.common.type_aliases import Schedule
     from stable_baselines3.common.utils import get_device
     import gym
-    SB3_AVAILABLE = True
-except ImportError:
-    # Fallback for environments without stable-baselines3
-    SB3_AVAILABLE = False
-    ActorCriticPolicy = object
-    BaseFeaturesExtractor = object
-    
-    class MockSchedule:
-        def __init__(self, value): self.value = value
-        def __call__(self, progress): return self.value
-    Schedule = MockSchedule
+except ImportError as e:
+    import logging
+    logging.getLogger(__name__).error("stable-baselines3 dependency is missing: %s", e)
+    raise
 
 # Configuration imports
 try:
@@ -1279,10 +1272,6 @@ def test_policy_forward_pass(
         >>> success = test_policy_forward_pass(obs_space, action_space, config)
     """
     try:
-        if not SB3_AVAILABLE:
-            logger.warning("stable-baselines3 not available, skipping forward pass test")
-            return True
-        
         # Create features extractor
         features_extractor = PlumeNavigationFeaturesExtractor(
             observation_space=observation_space,

--- a/tests/rl/test_policy_imports.py
+++ b/tests/rl/test_policy_imports.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def test_import_error_when_stable_baselines3_missing(monkeypatch):
+    """Policies module should raise ImportError when stable-baselines3 is absent."""
+    fake_torch = types.ModuleType("torch")
+    fake_nn = types.ModuleType("nn")
+    fake_nn.Module = object
+    fake_nn.Linear = object
+    fake_nn.BatchNorm1d = object
+    fake_nn.Dropout = object
+    fake_nn.ReLU = object
+    fake_nn.Tanh = object
+    fake_nn.ELU = object
+    fake_nn.LeakyReLU = object
+    fake_nn.SiLU = object
+    fake_nn.GELU = object
+    fake_nn.functional = types.ModuleType("functional")
+    fake_torch.nn = fake_nn
+    fake_torch.Tensor = object
+    fake_torch.distributions = types.ModuleType("distributions")
+    fake_torch.distributions.Normal = object
+    fake_torch.optim = types.ModuleType("optim")
+    fake_torch.optim.Optimizer = object
+    fake_torch.optim.Adam = object
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "torch.nn", fake_nn)
+    monkeypatch.setitem(sys.modules, "torch.nn.functional", fake_nn.functional)
+    monkeypatch.setitem(sys.modules, "torch.distributions", fake_torch.distributions)
+    monkeypatch.setitem(sys.modules, "torch.optim", fake_torch.optim)
+
+    monkeypatch.setitem(sys.modules, "stable_baselines3", None)
+    sys.modules.pop("odor_plume_nav.rl.policies", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("odor_plume_nav.rl.policies")


### PR DESCRIPTION
## Summary
- require stable-baselines3 for RL policies and log if missing
- add test ensuring policies import raises ImportError when stable-baselines3 absent

## Testing
- `pytest tests/rl/test_policy_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b62bdac7f08320b08285f1ff1c2d7c