### PR TITLE
fix: fail if Hydra ConfigStore is unavailable

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -9,15 +9,21 @@ from enum import Enum
 from pathlib import Path
 import logging
 import re
-from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator, field_serializer, AliasChoices
-try:
-    from hydra.core.config_store import ConfigStore
-    cs = ConfigStore.instance()
-except ImportError:
-    cs = None
-
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+    field_validator,
+    model_validator,
+    field_serializer,
+    AliasChoices,
+)
+from hydra.core.config_store import ConfigStore
 
 logger = logging.getLogger(__name__)
+
+cs = ConfigStore.instance()
+logger.debug("Initialized Hydra ConfigStore for configuration schemas")
 ENV_VAR_PATTERN = re.compile(r"^\$\{[^}]+\}$")
 
 

--- a/tests/config/test_schemas_requires_hydra.py
+++ b/tests/config/test_schemas_requires_hydra.py
@@ -1,0 +1,23 @@
+import importlib.util
+import builtins
+import pathlib
+
+import pytest
+
+
+def test_schemas_requires_hydra(monkeypatch):
+    """Ensure config schemas import fails loudly when Hydra is missing."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("hydra"):
+            raise ModuleNotFoundError("No module named 'hydra'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    schemas_path = pathlib.Path("src/plume_nav_sim/config/schemas.py")
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.config.schemas", schemas_path)
+    with pytest.raises(ImportError):
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- add test asserting config schemas raise ImportError when Hydra is absent
- import ConfigStore without fallback and log initialization

## Testing
- `pytest tests/config/test_schemas_requires_hydra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62ff7f574832088ff503fee3efbe8