### PR TITLE
refactor: require enhanced logging for frame cache

### DIFF
--- a/tests/utils/test_frame_cache_logging.py
+++ b/tests/utils/test_frame_cache_logging.py
@@ -1,0 +1,35 @@
+import builtins
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+def test_import_error_when_logging_setup_missing(monkeypatch):
+    """Frame cache should fail to import if logging helpers are unavailable."""
+    real_import = builtins.__import__
+
+    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "plume_nav_sim.utils.logging_setup":
+            raise ImportError("mocked missing logging_setup")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    # Create lightweight package placeholders to avoid importing full package
+    pkg = types.ModuleType("plume_nav_sim")
+    pkg.__path__ = []
+    utils_pkg = types.ModuleType("plume_nav_sim.utils")
+    utils_pkg.__path__ = []
+    sys.modules["plume_nav_sim"] = pkg
+    sys.modules["plume_nav_sim.utils"] = utils_pkg
+
+    module_path = Path("src/plume_nav_sim/utils/frame_cache.py")
+    spec = importlib.util.spec_from_file_location(
+        "plume_nav_sim.utils.frame_cache", module_path
+    )
+
+    with pytest.raises(ImportError):
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- add test ensuring frame cache import fails when logging helpers are missing
- remove logging fallback and import logging helpers unconditionally
- log memory pressure warnings with enhanced logger

## Testing
- `pytest tests/utils/test_frame_cache_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68b62ff994588320b11347da5762e826