### PR TITLE
refactor: require explicit binary sensor dependencies

### DIFF
--- a/tests/sensors/test_binary_sensor_dependencies.py
+++ b/tests/sensors/test_binary_sensor_dependencies.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim" / "core" / "sensors" / "binary_sensor.py"
+
+
+def run_missing_dependency_script(package: str) -> int:
+    script = textwrap.dedent(f"""
+    import builtins, sys, types, importlib.util
+
+    # stub minimal package structure
+    navigator = types.ModuleType('plume_nav_sim.protocols.navigator')
+    class NavigatorProtocol: ...
+    navigator.NavigatorProtocol = NavigatorProtocol
+    sensor = types.ModuleType('plume_nav_sim.protocols.sensor')
+    class SensorProtocol: ...
+    sensor.SensorProtocol = SensorProtocol
+    protocols = types.ModuleType('plume_nav_sim.protocols')
+    protocols.navigator = navigator
+    protocols.sensor = sensor
+    sys.modules['plume_nav_sim'] = types.ModuleType('plume_nav_sim')
+    sys.modules['plume_nav_sim.protocols'] = protocols
+    sys.modules['plume_nav_sim.protocols.navigator'] = navigator
+    sys.modules['plume_nav_sim.protocols.sensor'] = sensor
+
+    real_import = builtins.__import__
+    def mock_import(name, *args, **kwargs):
+        if name.startswith('{package}'):
+            raise ImportError('No module named {package}')
+        return real_import(name, *args, **kwargs)
+    builtins.__import__ = mock_import
+
+    spec = importlib.util.spec_from_file_location('binary_sensor', r"{MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['binary_sensor'] = module
+    try:
+        spec.loader.exec_module(module)
+    except ImportError:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+    """)
+    proc = subprocess.run([sys.executable, "-c", script])
+    return proc.returncode
+
+
+@pytest.mark.parametrize("missing", ["hydra", "loguru", "psutil"])
+def test_import_error_when_dependency_missing(missing):
+    assert run_missing_dependency_script(missing) == 0


### PR DESCRIPTION
## Summary
- enforce direct imports of hydra-core, loguru, and psutil in `BinarySensor`
- add tests validating `ImportError` when any dependency is missing

## Testing
- `pytest --noconftest tests/sensors/test_binary_sensor_dependencies.py -q`
- `pytest tests/sensors/test_binary_sensor_dependencies.py -q` *(fails: ImportError while loading conftest due to hydra/omegaconf validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68b72b034b048320b5a976b1777b8d10