### PR TITLE
feat(wind): require loguru and remove fallback logging

### DIFF
--- a/src/plume_nav_sim/models/wind/__init__.py
+++ b/src/plume_nav_sim/models/wind/__init__.py
@@ -65,9 +65,11 @@ Technical Integration:
 
 from __future__ import annotations
 import warnings
-import logging
 from typing import Dict, Any, List, Optional, Union, Type, Tuple
 from pathlib import Path
+
+from loguru import logger
+LOGURU_AVAILABLE = True
 
 # Core imports with graceful fallbacks during migration
 try:
@@ -89,14 +91,6 @@ except ImportError:
     DictConfig = dict
     HYDRA_AVAILABLE = False
 
-# Enhanced logging for debugging and performance monitoring
-try:
-    from loguru import logger
-    LOGURU_AVAILABLE = True
-except ImportError:
-    logger = logging.getLogger(__name__)
-    LOGURU_AVAILABLE = False
-
 # Import all wind field implementations with graceful fallbacks
 WIND_FIELD_IMPLEMENTATIONS = {}  # Registry for successful imports
 
@@ -114,10 +108,10 @@ try:
         'available': True
     }
     CONSTANT_WIND_AVAILABLE = True
-    logger.debug("ConstantWindField imported successfully") if LOGURU_AVAILABLE else None
+    logger.debug("ConstantWindField imported successfully")
 except ImportError as e:
     CONSTANT_WIND_AVAILABLE = False
-    logger.warning(f"ConstantWindField not available: {e}") if LOGURU_AVAILABLE else None
+    logger.warning(f"ConstantWindField not available: {e}")
     ConstantWindField = None
     ConstantWindFieldConfig = None
     create_constant_wind_field = None
@@ -136,10 +130,10 @@ try:
         'available': True
     }
     TURBULENT_WIND_AVAILABLE = True
-    logger.debug("TurbulentWindField imported successfully") if LOGURU_AVAILABLE else None
+    logger.debug("TurbulentWindField imported successfully")
 except ImportError as e:
     TURBULENT_WIND_AVAILABLE = False
-    logger.warning(f"TurbulentWindField not available: {e}") if LOGURU_AVAILABLE else None
+    logger.warning(f"TurbulentWindField not available: {e}")
     TurbulentWindField = None
     TurbulentWindFieldConfig = None
 
@@ -157,16 +151,16 @@ try:
         'available': True
     }
     TIME_VARYING_WIND_AVAILABLE = True
-    logger.debug("TimeVaryingWindField imported successfully") if LOGURU_AVAILABLE else None
+    logger.debug("TimeVaryingWindField imported successfully")
 except ImportError as e:
     TIME_VARYING_WIND_AVAILABLE = False
-    logger.warning(f"TimeVaryingWindField not available: {e}") if LOGURU_AVAILABLE else None
+    logger.warning(f"TimeVaryingWindField not available: {e}")
     TimeVaryingWindField = None
     TimeVaryingWindFieldConfig = None
 
 # Calculate total available implementations
 TOTAL_IMPLEMENTATIONS = len(WIND_FIELD_IMPLEMENTATIONS)
-logger.info(f"Loaded {TOTAL_IMPLEMENTATIONS} wind field implementations") if LOGURU_AVAILABLE else None
+logger.info(f"Loaded {TOTAL_IMPLEMENTATIONS} wind field implementations")
 
 # Ensure at least one implementation is available
 if TOTAL_IMPLEMENTATIONS == 0:
@@ -850,13 +844,12 @@ if _validation_results['status'] != 'healthy':
     warnings.warn(warning_msg, ImportWarning, stacklevel=2)
 
 # Log successful initialization
-if LOGURU_AVAILABLE:
-    logger.info(
-        f"Wind fields package initialized successfully",
-        total_implementations=_validation_results['implementations']['total'],
-        available_implementations=_validation_results['implementations']['available'],
-        status=_validation_results['status']
-    )
+logger.info(
+    f"Wind fields package initialized successfully",
+    total_implementations=_validation_results['implementations']['total'],
+    available_implementations=_validation_results['implementations']['available'],
+    status=_validation_results['status'],
+)
 
 # Define comprehensive public API for maximum flexibility
 __all__ = [

--- a/tests/models/test_wind_registry_logging.py
+++ b/tests/models/test_wind_registry_logging.py
@@ -1,0 +1,45 @@
+import importlib.util
+import builtins
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+def test_loguru_absence_raises_import_error(monkeypatch):
+    """Wind registry should raise ImportError if loguru is missing."""
+    monkeypatch.delitem(sys.modules, "loguru", raising=False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "loguru":
+            raise ImportError("No module named 'loguru'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Stub dependent modules to isolate loguru behavior
+    pkg = types.ModuleType("plume_nav_sim")
+    models_pkg = types.ModuleType("plume_nav_sim.models")
+    wind_pkg = types.ModuleType("plume_nav_sim.models.wind")
+    protocols_pkg = types.ModuleType("plume_nav_sim.protocols")
+    wind_field_mod = types.ModuleType("plume_nav_sim.protocols.wind_field")
+    setattr(wind_field_mod, "WindFieldProtocol", object)
+
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models", models_pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind", wind_pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.protocols", protocols_pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.protocols.wind_field", wind_field_mod)
+
+    for name in ["constant_wind", "turbulent_wind", "time_varying_wind"]:
+        mod = types.ModuleType(f"plume_nav_sim.models.wind.{name}")
+        monkeypatch.setitem(sys.modules, f"plume_nav_sim.models.wind.{name}", mod)
+
+    wind_path = Path(__file__).resolve().parents[2] / "src/plume_nav_sim/models/wind/__init__.py"
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.models.wind", wind_path)
+
+    with pytest.raises(ImportError):
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- add regression test for loguru absence in wind registry
- require loguru at import time and log wind field import failures directly
- remove redundant loguru import

## Testing
- `pytest tests/models/test_wind_registry_logging.py` *(fails: missing hydra-core and related config)*
- `pytest --noconftest tests/models/test_wind_registry_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68b72b0a3528832084e635e014623e30