### PR TITLE
Enforce recorder backend import failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ from typing import Any, Dict, Optional, Union, Generator, Tuple
 from unittest.mock import patch, MagicMock, Mock
 import sys
 import pathlib
+import logging
 
 # Update sys.path for new project structure
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "src"))
@@ -122,7 +123,7 @@ try:
         RecorderProtocol, StatsAggregatorProtocol
     )
     PROTOCOLS_AVAILABLE = True
-except ImportError:
+except Exception as exc:
     PROTOCOLS_AVAILABLE = False
     # Fallback protocol types for testing
     SourceProtocol = object
@@ -130,6 +131,9 @@ except ImportError:
     ActionInterfaceProtocol = object
     RecorderProtocol = object
     StatsAggregatorProtocol = object
+    logging.getLogger(__name__).warning(
+        "Protocol imports unavailable: %s", exc
+    )
 
 try:
     # Recorder backend testing dependencies
@@ -157,10 +161,13 @@ except ImportError:
 try:
     from plume_nav_sim.utils.seed_manager import SeedManager, SeedConfig
     SEED_MANAGER_AVAILABLE = True
-except ImportError:
+except Exception as exc:
     SEED_MANAGER_AVAILABLE = False
     SeedManager = None
     SeedConfig = None
+    logging.getLogger(__name__).warning(
+        "SeedManager unavailable: %s", exc
+    )
 
 
 @pytest.fixture

--- a/tests/recording/test_backend_registry_imports.py
+++ b/tests/recording/test_backend_registry_imports.py
@@ -1,0 +1,43 @@
+import importlib
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Ensure src directory on path
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+PACKAGE_ROOT = SRC_ROOT / "plume_nav_sim"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def test_backend_registry_import_error_on_missing_dependency(monkeypatch):
+    # Provide lightweight package stubs to avoid heavy top-level imports
+    root_pkg = types.ModuleType("plume_nav_sim")
+    root_pkg.__path__ = [str(PACKAGE_ROOT)]
+    sys.modules["plume_nav_sim"] = root_pkg
+
+    recording_pkg = types.ModuleType("plume_nav_sim.recording")
+    recording_pkg.__path__ = [str(PACKAGE_ROOT / "recording")]
+    recording_pkg.BaseRecorder = type("BaseRecorder", (), {})
+    sys.modules["plume_nav_sim.recording"] = recording_pkg
+
+    original_find_spec = importlib.machinery.PathFinder.find_spec
+
+    def fake_find_spec(fullname, path=None, target=None):
+        missing = {
+            "plume_nav_sim.recording.backends.parquet",
+            "plume_nav_sim.recording.backends.hdf5",
+            "plume_nav_sim.recording.backends.sqlite",
+        }
+        if fullname in missing:
+            return None
+        return original_find_spec(fullname, path=path, target=target)
+
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", staticmethod(fake_find_spec))
+    sys.modules.pop("plume_nav_sim.recording.backends", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.recording.backends")


### PR DESCRIPTION
## Summary
- import optional recorder backends at module load and raise `ImportError` on failure
- derive available backends directly from registry entries
- add regression test ensuring missing backend modules surface import errors
- warn and continue when Hydra-dependent imports fail in tests

## Testing
- `pytest tests/recording/test_backend_registry_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72b06ff0883209ad7f3379b0ec1c4