### PR TITLE
feat: add PySide6 and plotly to debug extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ pip install "plume_nav_sim[rl]"
 
 # v1.0 Optional dependency groups for enhanced capabilities
 pip install "plume_nav_sim[recording]"  # Multi-backend data persistence (pandas, pyarrow, h5py)
-pip install "plume_nav_sim[debug]"      # Interactive debugging GUI (PySide6, streamlit)
+pip install "plume_nav_sim[debug]"      # Interactive debugging GUI (PySide6, plotly, streamlit)
 pip install "plume_nav_sim[analysis]"   # Automated statistics collection (scipy, psutil)
 
 # Full installation with all v1.0 components

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,8 @@ recording = [
 ]
 debug = [
     # Debug GUI interface dependencies for interactive debugging
-    # "PySide6>=6.0.0",  # Temporarily disabled due to Python 3.12 compatibility issue
+    "PySide6>=6.0.0",
+    "plotly>=5.17.0",
     "streamlit>=1.0.0",
 ]
 analysis = [


### PR DESCRIPTION
## Summary
- include PySide6 and plotly in the debug optional dependency group
- document debug extras in README

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b794624028832082adebf682db2e5d