### PR TITLE
refactor: enforce spaces dependency in plume navigation env

### DIFF
--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -116,91 +116,19 @@ from plume_nav_sim.core.protocols import (
 NAVIGATOR_AVAILABLE = True
 
 # Enhanced space definitions with proper Gymnasium compliance
-try:
-    from plume_nav_sim.envs.spaces import (
-        ActionSpaceFactory, ObservationSpaceFactory, SensorAwareSpaceFactory, 
-        SpaceValidator, ReturnFormatConverter, WindDataConfig,
-        get_standard_action_space, get_standard_observation_space,
-        get_sensor_aware_observation_space, validate_sensor_observation_compatibility
-    )
-    SPACES_AVAILABLE = True
-except ImportError:
-    # Minimal fallback during migration
-    class ActionSpaceFactory:
-        @staticmethod
-        def create_continuous_action_space(**kwargs):
-            if GYMNASIUM_AVAILABLE:
-                return Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
-            return None
-    
-    class ObservationSpaceFactory:
-        @staticmethod
-        def create_navigation_observation_space(**kwargs):
-            if GYMNASIUM_AVAILABLE:
-                return DictSpace({
-                    "odor_concentration": Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32),
-                    "agent_position": Box(low=-1000.0, high=1000.0, shape=(2,), dtype=np.float32),
-                    "agent_orientation": Box(low=0.0, high=360.0, shape=(1,), dtype=np.float32)
-                })
-            return None
-        
-        @staticmethod
-        def create_dynamic_sensor_observation_space(sensors, **kwargs):
-            if GYMNASIUM_AVAILABLE:
-                return DictSpace({
-                    "odor_concentration": Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32),
-                    "agent_position": Box(low=-1000.0, high=1000.0, shape=(2,), dtype=np.float32),
-                    "agent_orientation": Box(low=0.0, high=360.0, shape=(1,), dtype=np.float32)
-                })
-            return None
-    
-    class SensorAwareSpaceFactory:
-        @staticmethod
-        def create_sensor_observation_space(sensors, **kwargs):
-            if GYMNASIUM_AVAILABLE:
-                return DictSpace({
-                    "odor_concentration": Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32),
-                    "agent_position": Box(low=-1000.0, high=1000.0, shape=(2,), dtype=np.float32),
-                    "agent_orientation": Box(low=0.0, high=360.0, shape=(1,), dtype=np.float32)
-                })
-            return None
-    
-    class SpaceValidator:
-        @staticmethod
-        def validate_gymnasium_compliance(space):
-            return True
-    
-    class ReturnFormatConverter:
-        @staticmethod
-        def to_legacy_format(gymnasium_return):
-            obs, reward, terminated, truncated, info = gymnasium_return
-            done = terminated or truncated
-            return obs, reward, done, info
-        
-        @staticmethod
-        def to_gymnasium_format(legacy_return):
-            obs, reward, done, info = legacy_return
-            terminated = done
-            truncated = False
-            return obs, reward, terminated, truncated, info
-    
-    class WindDataConfig:
-        def __init__(self, enabled=False, **kwargs):
-            self.enabled = enabled
-    
-    def get_standard_action_space():
-        return ActionSpaceFactory.create_continuous_action_space()
-    
-    def get_standard_observation_space():
-        return ObservationSpaceFactory.create_navigation_observation_space()
-    
-    def get_sensor_aware_observation_space(sensors, **kwargs):
-        return SensorAwareSpaceFactory.create_sensor_observation_space(sensors, **kwargs)
-    
-    def validate_sensor_observation_compatibility(obs, sensors, **kwargs):
-        return True
-    
-    SPACES_AVAILABLE = False
+from plume_nav_sim.envs.spaces import (
+    ActionSpaceFactory,
+    ObservationSpaceFactory,
+    SensorAwareSpaceFactory,
+    SpaceValidator,
+    ReturnFormatConverter,
+    WindDataConfig,
+    get_standard_action_space,
+    get_standard_observation_space,
+    get_sensor_aware_observation_space,
+    validate_sensor_observation_compatibility,
+)
+SPACES_AVAILABLE = True
 
 # Plume model implementations with fallback
 try:

--- a/tests/envs/test_plume_navigation_env_dependencies.py
+++ b/tests/envs/test_plume_navigation_env_dependencies.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import types
+import builtins
+import pytest
+
+def test_missing_spaces_module_raises_import_error(monkeypatch):
+    module_name = "plume_nav_sim.envs.plume_navigation_env"
+    sys.modules.pop(module_name, None)
+
+    # Mock hydra to avoid configuration side effects
+    hydra_module = types.ModuleType("hydra")
+    hydra_utils = types.ModuleType("hydra.utils")
+    hydra_utils.instantiate = lambda cfg, *a, **kw: cfg
+    sys.modules["hydra"] = hydra_module
+    sys.modules["hydra.utils"] = hydra_utils
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.envs.spaces":
+            raise ImportError("spaces module missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- add regression test for missing spaces module
- remove spaces fallbacks from `PlumeNavigationEnv` so import errors surface immediately

## Testing
- `pytest tests/envs/test_plume_navigation_env_dependencies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b794a1a9f08320865d2624f6a3c14f