### PR TITLE
refactor: drop env dependency fallbacks and add import tests

### DIFF
--- a/tests/envs/test_spaces_dependencies.py
+++ b/tests/envs/test_spaces_dependencies.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _import_spaces(monkeypatch):
+    package = types.ModuleType("plume_nav_sim")
+    package.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim")]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", package)
+    sys.modules.pop("plume_nav_sim.envs.spaces", None)
+    return importlib.import_module("plume_nav_sim.envs.spaces")
+
+
+def test_import_fails_without_gymnasium(monkeypatch):
+    monkeypatch.setitem(sys.modules, "gymnasium", None)
+    with pytest.raises(ImportError):
+        _import_spaces(monkeypatch)
+
+
+def test_import_fails_without_sensor_implementations(monkeypatch):
+    modules = [
+        "plume_nav_sim.core.sensors.binary_sensor",
+        "plume_nav_sim.core.sensors.concentration_sensor",
+        "plume_nav_sim.core.sensors.gradient_sensor",
+    ]
+    for mod in modules:
+        monkeypatch.setitem(sys.modules, mod, None)
+    with pytest.raises(ImportError):
+        _import_spaces(monkeypatch)


### PR DESCRIPTION
## Summary
- remove gymnasium and sensor implementation fallbacks from `spaces`
- add tests asserting ImportError when gymnasium or sensor modules are missing

## Testing
- `pytest tests/envs/test_spaces_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b794a2b9288320aab75e00e4437de3