### PR TITLE
refactor: remove core fallbacks and enforce submodule dependencies

### DIFF
--- a/src/plume_nav_sim/core/__init__.py
+++ b/src/plume_nav_sim/core/__init__.py
@@ -180,243 +180,59 @@ from .protocols import (
 from .navigator import Navigator, NavigatorFactory, create_navigator_from_config
 
 # New v1.0 source implementations per Section 0.2.1 source abstraction
-try:
-    from .sources import (
-        PointSource,
-        MultiSource,
-        DynamicSource,
-        create_source
-    )
-    SOURCES_AVAILABLE = True
-except ImportError:
-    # Sources will be created by other agents - create minimal fallback
-    def create_source(config):
-        """Placeholder until sources module is available."""
-        warnings.warn("Source implementations not yet available", UserWarning, stacklevel=2)
-        return None
-    
-    class PointSource:
-        """Placeholder for PointSource until sources module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("PointSource not yet available", UserWarning, stacklevel=2)
-    
-    class MultiSource:
-        """Placeholder for MultiSource until sources module is available.""" 
-        def __init__(self, **kwargs):
-            warnings.warn("MultiSource not yet available", UserWarning, stacklevel=2)
-    
-    class DynamicSource:
-        """Placeholder for DynamicSource until sources module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("DynamicSource not yet available", UserWarning, stacklevel=2)
-    
-    SOURCES_AVAILABLE = False
+from .sources import (
+    PointSource,
+    MultiSource,
+    DynamicSource,
+    create_source,
+)
 
 # New v1.0 boundary policy implementations per Section 0.2.1 boundary handling
-try:
-    from .boundaries import (
-        TerminateBoundary,
-        BounceBoundary,
-        WrapBoundary,
-        ClipBoundary,
-        create_boundary_policy
-    )
-    BOUNDARIES_AVAILABLE = True
-except ImportError:
-    # Boundaries will be created by other agents - create minimal fallback
-    def create_boundary_policy(policy_type, domain_bounds, **kwargs):
-        """Placeholder until boundaries module is available."""
-        warnings.warn("Boundary policy implementations not yet available", UserWarning, stacklevel=2)
-        return None
-    
-    class TerminateBoundary:
-        """Placeholder for TerminateBoundary until boundaries module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("TerminateBoundary not yet available", UserWarning, stacklevel=2)
-    
-    class BounceBoundary:
-        """Placeholder for BounceBoundary until boundaries module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("BounceBoundary not yet available", UserWarning, stacklevel=2)
-    
-    class WrapBoundary:
-        """Placeholder for WrapBoundary until boundaries module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("WrapBoundary not yet available", UserWarning, stacklevel=2)
-    
-    class ClipBoundary:
-        """Placeholder for ClipBoundary until boundaries module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("ClipBoundary not yet available", UserWarning, stacklevel=2)
-    
-    BOUNDARIES_AVAILABLE = False
+from .boundaries import (
+    TerminateBoundary,
+    BounceBoundary,
+    WrapBoundary,
+    ClipBoundary,
+    create_boundary_policy,
+)
 
 # New v1.0 action interface implementations per Section 0.2.1 action standardization
-try:
-    from .actions import (
-        Continuous2DAction,
-        CardinalDiscreteAction,
-        create_action_interface
-    )
-    ACTIONS_AVAILABLE = True
-except ImportError:
-    # Actions will be created by other agents - create minimal fallback
-    def create_action_interface(config):
-        """Placeholder until actions module is available."""
-        warnings.warn("Action interface implementations not yet available", UserWarning, stacklevel=2)
-        return None
-    
-    class Continuous2DAction:
-        """Placeholder for Continuous2DAction until actions module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("Continuous2DAction not yet available", UserWarning, stacklevel=2)
-    
-    class CardinalDiscreteAction:
-        """Placeholder for CardinalDiscreteAction until actions module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("CardinalDiscreteAction not yet available", UserWarning, stacklevel=2)
-    
-    ACTIONS_AVAILABLE = False
+from .actions import (
+    Continuous2DAction,
+    CardinalDiscreteAction,
+    create_action_interface,
+)
 
-# Controller implementations - handle case where they don't exist yet
-try:
-    from .controllers import (
-        SingleAgentController,
-        MultiAgentController,
-        SingleAgentParams,
-        MultiAgentParams,
-        create_controller_from_config
-    )
-    CONTROLLERS_AVAILABLE = True
-except ImportError:
-    # Controllers will be created by other agents - create minimal exports
-    from .navigator import SingleAgentController, MultiAgentController
-    
-    # Create placeholder parameter classes
-    class SingleAgentParams:
-        """Placeholder for SingleAgentParams until controllers module is available."""
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-    
-    class MultiAgentParams:
-        """Placeholder for MultiAgentParams until controllers module is available."""
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-    
-    def create_controller_from_config(config: Union[Dict[str, Any], 'DictConfig']) -> NavigatorProtocol:
-        """Placeholder function until controllers module is available."""
-        return Navigator.from_config(config).controller
-    
-    CONTROLLERS_AVAILABLE = False
+# Controller implementations
+from .controllers import (
+    SingleAgentController,
+    MultiAgentController,
+    SingleAgentParams,
+    MultiAgentParams,
+    create_controller_from_config,
+)
 
 # Simulation orchestration
-try:
-    from .simulation import run_simulation
-    SIMULATION_AVAILABLE = True
-except ImportError:
-    # Simulation module will be created by other agents - create minimal fallback
-    def run_simulation(*args, **kwargs):
-        """Placeholder for run_simulation until simulation module is available."""
-        warnings.warn(
-            "run_simulation placeholder active. Full implementation will be available "
-            "when plume_nav_sim.core.simulation module is created.",
-            UserWarning,
-            stacklevel=2
-        )
-        return {"status": "placeholder", "performance_metrics": {}}
-    
-    SIMULATION_AVAILABLE = False
+from .simulation import run_simulation
 
 # New v1.0 recording framework implementations per Section 0.2.1 data recording
-try:
-    from ..recording import (
-        RecorderFactory,
-        RecorderManager,
-        BaseRecorder
-    )
-    RECORDING_AVAILABLE = True
-except ImportError:
-    # Recording will be created by other agents - create minimal fallback
-    class RecorderFactory:
-        """Placeholder for RecorderFactory until recording module is available."""
-        @staticmethod
-        def create_recorder(config):
-            warnings.warn("RecorderFactory not yet available", UserWarning, stacklevel=2)
-            return None
-        
-        @staticmethod
-        def get_available_backends():
-            return ['none']
-        
-        @staticmethod
-        def validate_config(config):
-            return {'valid': False, 'error': 'RecorderFactory not available'}
-    
-    class RecorderManager:
-        """Placeholder for RecorderManager until recording module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("RecorderManager not yet available", UserWarning, stacklevel=2)
-    
-    class BaseRecorder:
-        """Placeholder for BaseRecorder until recording module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("BaseRecorder not yet available", UserWarning, stacklevel=2)
-    
-    RECORDING_AVAILABLE = False
+from ..recording import (
+    RecorderFactory,
+    RecorderManager,
+    BaseRecorder,
+)
 
 # New v1.0 analysis framework implementations per Section 0.2.1 statistics aggregation
-try:
-    from ..analysis import (
-        StatsAggregator,
-        generate_summary
-    )
-    ANALYSIS_AVAILABLE = True
-except Exception:
-    # Analysis will be created by other agents - create minimal fallback
-    def generate_summary(aggregator, episodes_data, output_path=None, **export_options):
-        """Placeholder until analysis module is available."""
-        warnings.warn("Analysis framework not yet available", UserWarning, stacklevel=2)
-        return {'status': 'placeholder', 'episode_count': 0}
-    
-    class StatsAggregator:
-        """Placeholder for StatsAggregator until analysis module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("StatsAggregator not yet available", UserWarning, stacklevel=2)
-    
-    ANALYSIS_AVAILABLE = False
+from ..analysis import (
+    StatsAggregator,
+    generate_summary,
+)
 
 # New v1.0 debug framework implementations per Section 0.2.1 enhanced debugging
-try:
-    from ..debug import (
-        DebugGUI,
-        plot_initial_state
-    )
-    DEBUG_AVAILABLE = True
-except ImportError:
-    # Debug will be created by other agents - create minimal fallback
-    def plot_initial_state(*args, **kwargs):
-        """Placeholder until debug module is available."""
-        warnings.warn("Debug plotting not yet available", UserWarning, stacklevel=2)
-        return None
-    
-    class DebugGUI:
-        """Placeholder for DebugGUI until debug module is available."""
-        def __init__(self, **kwargs):
-            warnings.warn("DebugGUI not yet available", UserWarning, stacklevel=2)
-        
-        def start_session(self):
-            return self
-        
-        def step_through(self):
-            return True
-        
-        def export_screenshots(self, output_dir='./debug_exports'):
-            return None
-        
-        def configure_backend(self, **kwargs):
-            pass
-    
-    DEBUG_AVAILABLE = False
+from ..debug import (
+    DebugGUI,
+    plot_initial_state,
+)
 
 # Hydra configuration support
 try:
@@ -638,7 +454,7 @@ def validate_core_module_integrity() -> Dict[str, Any]:
                     validation_results['issues'].append(
                         f"{controller_class.__name__} missing required method '{method_name}'"
                     )
-        validation_results['component_status']['Controllers'] = CONTROLLERS_AVAILABLE
+        validation_results['component_status']['Controllers'] = True
         
         # Validate extensibility hooks support
         for hook_method in ['compute_additional_obs', 'compute_extra_reward', 'on_episode_end']:
@@ -658,7 +474,7 @@ def validate_core_module_integrity() -> Dict[str, Any]:
         # Validate simulation function availability  
         if not callable(run_simulation):
             validation_results['issues'].append("run_simulation function not properly imported")
-        validation_results['component_status']['Simulation'] = SIMULATION_AVAILABLE
+        validation_results['component_status']['Simulation'] = True
         
         # Validate Gymnasium integration
         try:
@@ -749,16 +565,12 @@ def get_navigator_implementations() -> List[type]:
         >>> for impl in implementations:
         ...     print(f"Available: {impl.__name__}")
     """
-    implementations = []
-    
-    # Add core implementations
-    if CONTROLLERS_AVAILABLE:
-        implementations.extend([SingleAgentController, MultiAgentController])
-    
+    implementations = [SingleAgentController, MultiAgentController]
+
     # Add Navigator wrapper if available
     if hasattr(Navigator, '__class__'):
         implementations.append(Navigator)
-    
+
     return implementations
 
 
@@ -976,11 +788,11 @@ try:
         _module_logger.debug(
             "Core navigation module initialized successfully",
             exported_components=len(__all__),
-            controllers_available=CONTROLLERS_AVAILABLE,
-            simulation_available=SIMULATION_AVAILABLE,
+            controllers_available=True,
+            simulation_available=True,
             hydra_available=HYDRA_AVAILABLE,
             extensibility_hooks_enabled=True,
-            dual_api_support=True
+            dual_api_support=True,
         )
         
 except ImportError:

--- a/tests/core/test_core_init_dependencies.py
+++ b/tests/core/test_core_init_dependencies.py
@@ -1,0 +1,71 @@
+import builtins
+import importlib
+import sys
+import types
+
+import pytest
+
+CORE_SUBMODULES = [
+    "plume_nav_sim.core.sources",
+    "plume_nav_sim.core.boundaries",
+    "plume_nav_sim.core.actions",
+    "plume_nav_sim.core.controllers",
+    "plume_nav_sim.core.simulation",
+    "plume_nav_sim.recording",
+    "plume_nav_sim.analysis",
+    "plume_nav_sim.debug",
+]
+
+
+@pytest.mark.parametrize("missing", CORE_SUBMODULES)
+def test_core_import_raises_on_missing_submodule(monkeypatch, missing):
+    # Provide stub SpacesFactory to allow core import baseline
+    dummy_spaces = types.ModuleType("spaces")
+    dummy_spaces.SpacesFactory = object
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.envs.spaces", dummy_spaces)
+
+    # Stub debug module to avoid importing heavy dependencies
+    dummy_debug = types.ModuleType("debug")
+    dummy_debug.DebugGUI = object
+    dummy_debug.plot_initial_state = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.debug", dummy_debug)
+
+    # Stub recording and analysis modules
+    dummy_recording = types.ModuleType("recording")
+    dummy_recording.RecorderFactory = object
+    dummy_recording.RecorderManager = object
+    dummy_recording.BaseRecorder = object
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.recording", dummy_recording)
+
+    dummy_analysis = types.ModuleType("analysis")
+    dummy_analysis.StatsAggregator = object
+    dummy_analysis.generate_summary = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.analysis", dummy_analysis)
+
+    dummy_sensors = types.ModuleType("sensors")
+    dummy_sensors.create_sensor_from_config = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.core.sensors", dummy_sensors)
+
+    # Stub utils package to avoid Hydra requirements
+    dummy_utils = types.ModuleType("utils")
+    dummy_utils.visualization = types.ModuleType("visualization")
+    dummy_utils.visualization.SimulationVisualization = object
+    dummy_utils.visualization.visualize_trajectory = lambda *a, **k: None
+    dummy_utils.logging_setup = types.ModuleType("logging_setup")
+    dummy_utils.logging_setup.correlation_context = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.utils", dummy_utils)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.utils.visualization", dummy_utils.visualization)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.utils.logging_setup", dummy_utils.logging_setup)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == missing or name.startswith(f"{missing}."):
+            raise ImportError(f"No module named '{missing}'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("plume_nav_sim.core", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.core")


### PR DESCRIPTION
## Summary
- remove placeholder fallbacks from `plume_nav_sim.core` and import real submodules directly
- add regression test to ensure `plume_nav_sim.core` raises `ImportError` when a core submodule is missing

## Testing
- `pytest tests/core/test_core_init_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b794a4eaf88320bc5856772b4d49bf