### PR TITLE
refactor: remove dependency fallbacks in navigator

### DIFF
--- a/src/plume_nav_sim/core/navigator.py
+++ b/src/plume_nav_sim/core/navigator.py
@@ -100,30 +100,10 @@ except ImportError as exc:
         "plume_nav_sim.core.controllers could not be imported."
     ) from exc
 
-# Hydra imports for configuration integration
-try:
-    from omegaconf import DictConfig
-    HYDRA_AVAILABLE = True
-except ImportError:
-    # Fallback for environments without Hydra
-    DictConfig = dict
-    HYDRA_AVAILABLE = False
-
-# Gymnasium imports for modern API support
-try:
-    import gymnasium
-    from gymnasium import spaces
-    GYMNASIUM_AVAILABLE = True
-except ImportError:
-    # Fallback compatibility
-    try:
-        import gym as gymnasium
-        from gym import spaces
-        GYMNASIUM_AVAILABLE = True
-    except ImportError:
-        gymnasium = None
-        spaces = None
-        GYMNASIUM_AVAILABLE = False
+# Required dependencies
+from omegaconf import DictConfig
+import gymnasium
+from gymnasium import spaces
 
 
 class Navigator:

--- a/tests/core/test_navigator_dependencies.py
+++ b/tests/core/test_navigator_dependencies.py
@@ -1,0 +1,33 @@
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+
+def _install_dummy_controllers(monkeypatch):
+    dummy = types.ModuleType("plume_nav_sim.core.controllers")
+    dummy.SingleAgentController = object
+    dummy.MultiAgentController = object
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.core.controllers", dummy)
+
+
+def _load_navigator(monkeypatch, missing_modules):
+    _install_dummy_controllers(monkeypatch)
+    for name in missing_modules:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    loader = SourceFileLoader("navigator", str(Path("src/plume_nav_sim/core/navigator.py")))
+    module = types.ModuleType("navigator")
+    loader.exec_module(module)
+    return module
+
+
+def test_import_error_when_hydra_missing(monkeypatch):
+    with pytest.raises(ImportError):
+        _load_navigator(monkeypatch, ["omegaconf"])
+
+
+def test_import_error_when_gymnasium_missing(monkeypatch):
+    with pytest.raises(ImportError):
+        _load_navigator(monkeypatch, ["gymnasium", "gym"])


### PR DESCRIPTION
## Summary
- remove Hydra and gymnasium fallbacks from navigator
- add tests asserting ImportError when dependencies missing

## Testing
- `pytest tests/core/test_navigator_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b794a35cc48320b62bc8c44e53d509