### PR TITLE
fix(shims): surface ImportError when gym_make is unavailable

### DIFF
--- a/src/plume_nav_sim/shims/__init__.py
+++ b/src/plume_nav_sim/shims/__init__.py
@@ -36,39 +36,11 @@ import warnings
 # COMPATIBILITY FUNCTION IMPORTS
 # =============================================================================
 
-try:
-    # Import the primary gym_make compatibility function
-    from .gym_make import gym_make
-    _gym_make_available = True
-    
-except ImportError as e:
-    # gym_make.py not available - provide a fallback with clear error
-    warnings.warn(
-        f"Failed to import gym_make compatibility function: {e}. "
-        "Legacy gym.make() compatibility is not available. "
-        "Please use gymnasium.make() directly for environment creation.",
-        ImportWarning,
-        stacklevel=2
-    )
-    
-    def gym_make(*args, **kwargs):
-        """
-        Fallback gym_make function when compatibility layer is unavailable.
-        
-        This function provides a clear error message when the main gym_make
-        compatibility function cannot be imported, guiding users to use
-        the modern gymnasium.make() API directly.
-        """
-        raise ImportError(
-            "The gym_make compatibility function is not available. "
-            "This typically means the gym_make.py module is missing or has import errors. "
-            "Please use gymnasium.make() directly:\n\n"
-            "  import gymnasium\n"
-            "  env = gymnasium.make('PlumeNavSim-v0')\n\n"
-            "For migration guidance, see plume_nav_sim.get_api_migration_guide()"
-        )
-    
-    _gym_make_available = False
+# Import the primary gym_make compatibility function directly. Any import
+# failure should surface immediately to signal missing dependencies.
+from .gym_make import gym_make
+
+_gym_make_available = True
 
 # =============================================================================
 # SHIMS MODULE FEATURE DETECTION

--- a/tests/shims/test_gym_make_availability.py
+++ b/tests/shims/test_gym_make_availability.py
@@ -1,0 +1,20 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_missing_gym_make_raises_import_error(monkeypatch):
+    """Importing plume_nav_sim.shims should fail when gym_make is unavailable."""
+    sys.modules.pop("plume_nav_sim.shims", None)
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "plume_nav_sim.shims.gym_make":
+            raise ImportError("mocked missing gym_make")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.shims")


### PR DESCRIPTION
## Summary
- remove gym_make fallback and import at module load
- add test ensuring shim import fails when gym_make is missing

## Testing
- `pytest tests/shims/test_gym_make_availability.py`


------
https://chatgpt.com/codex/tasks/task_e_68b794a79b548320821727060e891386