### PR TITLE
refactor: enforce loguru for seed utilities

### DIFF
--- a/src/plume_nav_sim/utils/seed_utils.py
+++ b/src/plume_nav_sim/utils/seed_utils.py
@@ -13,12 +13,15 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 import threading
 import random
 import numpy as np
+import logging
 
 try:  # Prefer loguru if available for consistency with project logging
     from loguru import logger
-except Exception:  # pragma: no cover - fallback
-    import logging
-    logger = logging.getLogger(__name__)
+except ImportError as exc:  # pragma: no cover - explicit failure
+    logging.getLogger(__name__).error(
+        "loguru is required for seed utilities: %s", exc
+    )
+    raise
 
 _THREAD_LOCAL = threading.local()
 from odor_plume_nav.utils.seed_manager import (

--- a/tests/utils/test_seed_utils_logging.py
+++ b/tests/utils/test_seed_utils_logging.py
@@ -1,0 +1,35 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+def test_importerror_when_loguru_missing(monkeypatch):
+    """Seed utils should raise if loguru is unavailable."""
+    monkeypatch.setitem(sys.modules, "loguru", None)
+
+    opn_utils = types.ModuleType("odor_plume_nav.utils")
+    opn_utils.__path__ = []
+    monkeypatch.setitem(sys.modules, "odor_plume_nav", types.ModuleType("odor_plume_nav"))
+    monkeypatch.setitem(sys.modules, "odor_plume_nav.utils", opn_utils)
+
+    stub_seed_manager = types.ModuleType("seed_manager")
+    stub_seed_manager.SeedManager = object
+    stub_seed_manager.get_current_seed = lambda: 0
+    monkeypatch.setitem(sys.modules, "odor_plume_nav.utils.seed_manager", stub_seed_manager)
+
+    stub_seed_utils = types.ModuleType("seed_utils")
+    def _cm(*args, **kwargs):
+        yield
+    stub_seed_utils.seed_context_manager = _cm
+    monkeypatch.setitem(sys.modules, "odor_plume_nav.utils.seed_utils", stub_seed_utils)
+
+    seed_utils_path = pathlib.Path(__file__).resolve().parents[2] / "src/plume_nav_sim/utils/seed_utils.py"
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.utils.seed_utils", seed_utils_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plume_nav_sim.utils.seed_utils"] = module
+
+    with pytest.raises(ImportError):
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- require loguru in seed_utils and log error if missing
- add test confirming ImportError when loguru is absent

## Testing
- `pytest tests/utils/test_seed_utils_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68b794a8284c8320a16424b7a4505c96