### PR TITLE
fix: enforce Hydra presence for constant wind model

### DIFF
--- a/src/plume_nav_sim/models/wind/constant_wind.py
+++ b/src/plume_nav_sim/models/wind/constant_wind.py
@@ -61,14 +61,16 @@ import numpy as np
 # Core protocol import for interface compliance
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 
+logger = logging.getLogger(__name__)
+
 # Configuration management imports
 try:
     from omegaconf import DictConfig
-    HYDRA_AVAILABLE = True
 except ImportError:
-    # Fallback for environments without Hydra
-    DictConfig = dict
-    HYDRA_AVAILABLE = False
+    logger.error(
+        "Missing optional dependency 'omegaconf'. Install hydra-core to enable configuration support."
+    )
+    raise
 
 
 @dataclass

--- a/tests/models/test_constant_wind_dependencies.py
+++ b/tests/models/test_constant_wind_dependencies.py
@@ -1,0 +1,43 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "plume_nav_sim"
+    / "models"
+    / "wind"
+    / "constant_wind.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_protocols(monkeypatch):
+    proto_module = types.ModuleType("plume_nav_sim.protocols.wind_field")
+    class DummyProtocol:  # minimal stand-in for protocol
+        pass
+    proto_module.WindFieldProtocol = DummyProtocol
+    protocols_module = types.ModuleType("plume_nav_sim.protocols")
+    protocols_module.wind_field = proto_module
+    package_module = types.ModuleType("plume_nav_sim")
+    package_module.protocols = protocols_module
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", package_module)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.protocols", protocols_module)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.protocols.wind_field", proto_module)
+    yield
+
+
+def test_import_error_without_hydra(monkeypatch, caplog):
+    monkeypatch.setitem(sys.modules, "omegaconf", None)
+    spec = importlib.util.spec_from_file_location("constant_wind", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["constant_wind"] = module
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ImportError):
+            spec.loader.exec_module(module)
+        assert "omegaconf" in caplog.text


### PR DESCRIPTION
## Summary
- log error and raise when Hydra (omegaconf) is missing in ConstantWindField
- add test ensuring ConstantWindField import fails when Hydra is absent

## Testing
- `pytest tests/models/test_constant_wind_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b794aa58bc8320b3916ef883c50957