### PR TITLE
feat(models): simplify registry listing and log queries

### DIFF
--- a/src/plume_nav_sim/models/__init__.py
+++ b/src/plume_nav_sim/models/__init__.py
@@ -648,18 +648,9 @@ def list_available_plume_models() -> List[str]:
         >>> models = list_available_plume_models()
         >>> print(f"Available plume models: {models}")
     """
-    available_models = list(_PLUME_MODEL_REGISTRY.keys())
-    
-    # Add fallback models that have direct import support
-    fallback_models = ['GaussianPlumeModel', 'TurbulentPlumeModel', 'VideoPlumeAdapter']
-    for model in fallback_models:
-        if model not in available_models:
-            # Check if import status indicates availability
-            status = _IMPORT_STATUS['plume_models'].get(model, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_models.append(model)
-    
-    return sorted(available_models)
+    models = sorted(_PLUME_MODEL_REGISTRY.keys())
+    logger.debug("Available plume models: {}", models)
+    return models
 
 
 def list_available_wind_fields() -> List[str]:
@@ -669,16 +660,9 @@ def list_available_wind_fields() -> List[str]:
     Returns:
         List[str]: List of wind field type names that can be instantiated
     """
-    available_fields = list(_WIND_FIELD_REGISTRY.keys())
-    
-    fallback_fields = ['ConstantWindField', 'TurbulentWindField', 'TimeVaryingWindField']
-    for field in fallback_fields:
-        if field not in available_fields:
-            status = _IMPORT_STATUS['wind_fields'].get(field, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_fields.append(field)
-    
-    return sorted(available_fields)
+    fields = sorted(_WIND_FIELD_REGISTRY.keys())
+    logger.debug("Available wind fields: {}", fields)
+    return fields
 
 
 def list_available_sensors() -> List[str]:
@@ -688,16 +672,9 @@ def list_available_sensors() -> List[str]:
     Returns:
         List[str]: List of sensor type names that can be instantiated
     """
-    available_sensors = list(_SENSOR_REGISTRY.keys())
-    
-    fallback_sensors = ['BinarySensor', 'ConcentrationSensor', 'GradientSensor']
-    for sensor in fallback_sensors:
-        if sensor not in available_sensors:
-            status = _IMPORT_STATUS['sensors'].get(sensor, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_sensors.append(sensor)
-    
-    return sorted(available_sensors)
+    sensors = sorted(_SENSOR_REGISTRY.keys())
+    logger.debug("Available sensors: {}", sensors)
+    return sensors
 
 
 def get_model_registry() -> Dict[str, Dict[str, Any]]:

--- a/tests/models/test_registry_listing.py
+++ b/tests/models/test_registry_listing.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+# Load models module directly to avoid package import side effects
+models_path = Path(__file__).resolve().parents[2] / "src/plume_nav_sim/models/__init__.py"
+spec = importlib.util.spec_from_file_location("plume_nav_sim.models", models_path)
+models = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(models)
+
+
+def test_list_available_plume_models_no_fallback_and_logging(monkeypatch):
+    monkeypatch.setattr(models, "_PLUME_MODEL_REGISTRY", {"FooModel": {"class": object}})
+    with patch.object(models.logger, "debug") as mock_debug:
+        assert models.list_available_plume_models() == ["FooModel"]
+        mock_debug.assert_called_once()
+        args, kwargs = mock_debug.call_args
+        assert args[0] == "Available plume models: {}"
+        assert args[1] == ["FooModel"]
+
+
+def test_list_available_wind_fields_no_fallback_and_logging(monkeypatch):
+    monkeypatch.setattr(models, "_WIND_FIELD_REGISTRY", {"FooField": {"class": object}})
+    with patch.object(models.logger, "debug") as mock_debug:
+        assert models.list_available_wind_fields() == ["FooField"]
+        mock_debug.assert_called_once()
+        args, kwargs = mock_debug.call_args
+        assert args[0] == "Available wind fields: {}"
+        assert args[1] == ["FooField"]
+
+
+def test_list_available_sensors_no_fallback_and_logging(monkeypatch):
+    monkeypatch.setattr(models, "_SENSOR_REGISTRY", {"FooSensor": {"class": object}})
+    with patch.object(models.logger, "debug") as mock_debug:
+        assert models.list_available_sensors() == ["FooSensor"]
+        mock_debug.assert_called_once()
+        args, kwargs = mock_debug.call_args
+        assert args[0] == "Available sensors: {}"
+        assert args[1] == ["FooSensor"]


### PR DESCRIPTION
## Summary
- remove fallback model/field/sensor entries from registry queries
- log available registry entries at debug level
- test registry listing without fallback behavior

## Testing
- `pytest tests/models/test_registry_listing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b868ebc2bc8320a7468ed8d32149ca