### PR TITLE
feat: raise errors for invalid recording backends

### DIFF
--- a/src/plume_nav_sim/recording/backends/__init__.py
+++ b/src/plume_nav_sim/recording/backends/__init__.py
@@ -55,7 +55,6 @@ Examples:
 """
 
 from typing import Dict, List, Optional, Type, Union, Any, TYPE_CHECKING
-import warnings
 import logging
 
 # Import RecorderProtocol for type validation
@@ -107,57 +106,17 @@ SQLITE_AVAILABLE = 'sqlite' in BACKEND_REGISTRY
 
 
 def get_available_backends() -> List[str]:
-    """
-    Get list of available recording backends with dependency validation.
-    
-    Performs runtime capability detection to determine which backends are available
-    based on optional dependency availability. The null backend is always available
-    as a fallback option when other backends fail or dependencies are missing.
-    
-    Returns:
-        List[str]: List of available backend names that can be instantiated
-        
-    Notes:
-        Backend availability is determined by:
-        - Successful import of backend implementation classes
-        - Availability of required optional dependencies (pandas, h5py, pyarrow)
-        - Runtime validation of key backend functionality
-        
-        The returned list is ordered by performance preference:
-        1. null - Zero-overhead disabled recording
-        2. parquet - High-performance columnar storage  
-        3. hdf5 - Hierarchical scientific data storage
-        4. sqlite - Embedded relational database storage
-        
-    Examples:
-        Check available backends for UI display:
-        >>> available = get_available_backends()
-        >>> print(f"Recorder backends: {', '.join(available)}")
-        
-        Conditional backend selection:
-        >>> if 'parquet' in get_available_backends():
-        ...     backend_config = {'backend': 'parquet'}
-        ... else:
-        ...     backend_config = {'backend': 'null'}
-    """
-    available_backends = []
-    
-    # Null backend is always available as fallback
-    available_backends.append('null')
-    
-    # Check optional backends with dependency validation
-    if 'parquet' in BACKEND_REGISTRY:
-        available_backends.append('parquet')
+    """Get list of available recording backends with dependency validation."""
+
+    available_backends = list(BACKEND_REGISTRY.keys())
+
+    if 'parquet' in available_backends:
         logger.debug("ParquetRecorder available")
-
-    if 'hdf5' in BACKEND_REGISTRY:
-        available_backends.append('hdf5')
+    if 'hdf5' in available_backends:
         logger.debug("HDF5Recorder available")
-
-    if 'sqlite' in BACKEND_REGISTRY:
-        available_backends.append('sqlite')
+    if 'sqlite' in available_backends:
         logger.debug("SQLiteRecorder available")
-    
+
     logger.info(f"Available recording backends: {available_backends}")
     return available_backends
 
@@ -165,71 +124,20 @@ def get_available_backends() -> List[str]:
 def create_backend(
     config: Union[Dict[str, Any], Any],
     backend_name: Optional[str] = None,
-    fallback_to_null: bool = True
 ) -> 'BaseRecorder':
-    """
-    Create recording backend instance from configuration with automatic fallback handling.
-    
-    Factory function providing configuration-driven backend instantiation with comprehensive
-    error handling and automatic fallback to NullRecorder when primary backends fail or
-    dependencies are unavailable. Supports both dictionary configuration and structured
-    configuration objects for flexible integration patterns.
-    
+    """Create recording backend instance from configuration.
+
     Args:
         config: Backend configuration as dictionary or structured config object.
-            Expected to contain 'backend' field specifying backend type and
-            backend-specific parameters for initialization.
-        backend_name: Optional explicit backend name override. If provided,
-            takes precedence over config['backend'] field.
-        fallback_to_null: Enable automatic fallback to NullRecorder when primary
-            backend fails (default: True). Set to False to raise exceptions.
-            
+        backend_name: Optional explicit backend name override.
+
     Returns:
-        BaseRecorder: Configured recorder backend instance implementing RecorderProtocol
-        
+        BaseRecorder: Configured recorder backend instance implementing RecorderProtocol.
+
     Raises:
-        ValueError: If backend_name is unknown and fallback_to_null=False
-        ImportError: If backend dependencies are missing and fallback_to_null=False
-        TypeError: If config format is invalid
-        
-    Notes:
-        Backend selection priority:
-        1. Explicit backend_name parameter if provided
-        2. config['backend'] field from configuration dictionary/object
-        3. config.backend attribute from structured configuration
-        4. NullRecorder fallback if fallback_to_null=True
-        
-        Fallback behavior with informative warnings:
-        - Missing dependencies trigger automatic NullRecorder fallback
-        - Invalid configurations trigger validation error with fallback
-        - Unknown backend names trigger warning with fallback suggestion
-        
-    Examples:
-        Dictionary configuration with automatic backend selection:
-        >>> config = {
-        ...     'backend': 'parquet',
-        ...     'compression': 'snappy',
-        ...     'buffer_size': 1000
-        ... }
-        >>> recorder = create_backend(config)
-        
-        Explicit backend override with fallback handling:
-        >>> recorder = create_backend(config, backend_name='hdf5', fallback_to_null=True)
-        
-        Structured configuration object:
-        >>> from dataclasses import dataclass
-        >>> @dataclass
-        >>> class RecorderConfig:
-        ...     backend: str = 'sqlite'
-        ...     buffer_size: int = 500
-        >>> config = RecorderConfig()
-        >>> recorder = create_backend(config)
-        
-        Error handling without fallback:
-        >>> try:
-        ...     recorder = create_backend(config, fallback_to_null=False)
-        ... except ImportError as e:
-        ...     print(f"Backend dependency missing: {e}")
+        ValueError: If backend_name is unknown or not provided in config.
+        ImportError: If backend dependencies are missing.
+        TypeError: If config format is invalid.
     """
     # Extract backend name from various configuration formats
     target_backend = backend_name
@@ -241,58 +149,32 @@ def create_backend(
         elif hasattr(config, 'get'):
             target_backend = config.get('backend')
         else:
-            if not fallback_to_null:
-                raise TypeError("Invalid config format: must be dict or have 'backend' attribute")
-            warnings.warn("No backend specified in config, falling back to NullRecorder")
-            target_backend = 'null'
-    
+            raise TypeError("Invalid config format: must be dict or have 'backend' attribute")
+
+    if target_backend is None:
+        raise ValueError("No backend specified in config")
+
     # Validate backend name
     if target_backend not in BACKEND_REGISTRY:
         available = list(BACKEND_REGISTRY.keys())
-        error_msg = f"Unknown backend '{target_backend}'. Available: {available}"
-        
-        if fallback_to_null:
-            warnings.warn(f"{error_msg}. Falling back to NullRecorder.")
-            target_backend = 'null'
-        else:
-            raise ValueError(error_msg)
-    
-    # Attempt backend instantiation with dependency validation
+        raise ValueError(f"Unknown backend '{target_backend}'. Available: {available}")
+
     backend_class = BACKEND_REGISTRY[target_backend]
-    
+
     try:
-        # Create backend instance with configuration
         recorder = backend_class(config)
         logger.info(f"Successfully created {target_backend} recorder backend")
         return recorder
-        
     except ImportError as e:
-        # Handle missing dependencies with informative error messages
         dependency_suggestions = {
             'parquet': "Install PyArrow: pip install pyarrow>=10.0.0",
             'hdf5': "Install h5py: pip install h5py>=3.0.0",
-            'sqlite': "SQLite3 should be available in standard library"
+            'sqlite': "SQLite3 should be available in standard library",
         }
-        
         suggestion = dependency_suggestions.get(target_backend, "Check backend dependencies")
-        error_msg = f"Failed to create {target_backend} backend: {e}. {suggestion}"
-        
-        if fallback_to_null:
-            warnings.warn(f"{error_msg}. Falling back to NullRecorder.")
-            # Recursive call with null backend (guaranteed to work)
-            return create_backend(config, backend_name='null', fallback_to_null=False)
-        else:
-            raise ImportError(error_msg) from e
-            
+        raise ImportError(f"Failed to create {target_backend} backend: {e}. {suggestion}") from e
     except Exception as e:
-        # Handle other instantiation errors
-        error_msg = f"Failed to create {target_backend} backend: {e}"
-        
-        if fallback_to_null:
-            warnings.warn(f"{error_msg}. Falling back to NullRecorder.")
-            return create_backend(config, backend_name='null', fallback_to_null=False)
-        else:
-            raise RuntimeError(error_msg) from e
+        raise RuntimeError(f"Failed to create {target_backend} backend: {e}") from e
 
 
 def get_backend_capabilities() -> Dict[str, Dict[str, Any]]:

--- a/tests/recording/test_create_backend.py
+++ b/tests/recording/test_create_backend.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+PACKAGE_ROOT = SRC_ROOT / "plume_nav_sim"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def load_backends_module(monkeypatch):
+    root_pkg = types.ModuleType("plume_nav_sim")
+    root_pkg.__path__ = [str(PACKAGE_ROOT)]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", root_pkg)
+
+    recording_pkg = types.ModuleType("plume_nav_sim.recording")
+    recording_pkg.__path__ = [str(PACKAGE_ROOT / "recording")]
+    recording_pkg.BaseRecorder = type("BaseRecorder", (), {})
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.recording", recording_pkg)
+
+    stubs = {
+        "parquet": "ParquetRecorder",
+        "hdf5": "HDF5Recorder",
+        "sqlite": "SQLiteRecorder",
+    }
+    for name, cls_name in stubs.items():
+        module = types.ModuleType(f"plume_nav_sim.recording.backends.{name}")
+        setattr(module, cls_name, type(cls_name, (), {"__init__": lambda self, config: None}))
+        monkeypatch.setitem(sys.modules, f"plume_nav_sim.recording.backends.{name}", module)
+
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.recording.backends", raising=False)
+    return importlib.import_module("plume_nav_sim.recording.backends")
+
+
+def test_unknown_backend_raises_value_error(monkeypatch):
+    backends = load_backends_module(monkeypatch)
+    with pytest.raises(ValueError):
+        backends.create_backend({'backend': 'does_not_exist'})
+
+
+def test_backend_dependency_error_raises_import_error(monkeypatch):
+    backends = load_backends_module(monkeypatch)
+
+    class DummyRecorder:
+        def __init__(self, config):
+            raise ImportError('missing dependency')
+
+    monkeypatch.setitem(backends.BACKEND_REGISTRY, 'dummy', DummyRecorder)
+    try:
+        with pytest.raises(ImportError):
+            backends.create_backend({'backend': 'dummy'})
+    finally:
+        backends.BACKEND_REGISTRY.pop('dummy', None)


### PR DESCRIPTION
## Summary
- remove silent NullRecorder fallbacks and expose available backends directly
- raise ValueError or ImportError when backend selection or dependencies are invalid
- add and update tests to verify backend misconfiguration errors

## Testing
- `pytest tests/recording/test_create_backend.py tests/recording/test_backend_registry_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b869dc73cc83209eac4451944f545f