### PR TITLE
feat(cli): require database layer

### DIFF
--- a/tests/cli/test_missing_db.py
+++ b/tests/cli/test_missing_db.py
@@ -1,0 +1,28 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+def test_import_error_when_db_missing(monkeypatch):
+    """Importing CLI main should fail if the database session module is absent."""
+    # Simulate missing database session layer
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.db.session", None)
+
+    path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "src"
+        / "plume_nav_sim"
+        / "cli"
+        / "main.py"
+    )
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.cli.main", path)
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ImportError) as exc:
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    assert "database layer" in str(exc.value).lower()


### PR DESCRIPTION
## Summary
- enforce presence of database session utilities in CLI and drop fallback
- raise explicit ImportError when database layer is missing
- add CLI import test for absent database module

## Testing
- `pytest tests/cli/test_missing_db.py -q`
- `pytest tests/cli/test_missing_hydra.py::test_import_error_when_hydra_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b869eb08d0832084ca57c9f4d46323