### PR TITLE
feat: error on missing debug viewer backend

### DIFF
--- a/tests/debug/test_debug_cli_backends.py
+++ b/tests/debug/test_debug_cli_backends.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+import importlib.util
+import types
+import sys
+import logging
+
+import pytest
+
+# Stub external dependencies to avoid heavy imports
+hydra_stub = types.ModuleType("hydra")
+sys.modules["hydra"] = hydra_stub
+
+omegaconf_stub = types.ModuleType("omegaconf")
+class DictConfig(dict):
+    pass
+omegaconf_stub.DictConfig = DictConfig
+sys.modules["omegaconf"] = omegaconf_stub
+
+rich_stub = types.ModuleType("rich")
+rich_stub.print = print
+sys.modules["rich"] = rich_stub
+
+console_stub = types.ModuleType("rich.console")
+class Console:  # minimal stub
+    def print(self, *args, **kwargs):
+        pass
+console_stub.Console = Console
+sys.modules["rich.console"] = console_stub
+
+progress_stub = types.ModuleType("rich.progress")
+class Progress:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def add_task(self, *args, **kwargs):
+        return 0
+    def update(self, *args, **kwargs):
+        pass
+progress_stub.Progress = Progress
+progress_stub.SpinnerColumn = object
+progress_stub.TextColumn = object
+progress_stub.BarColumn = object
+progress_stub.TimeRemainingColumn = object
+sys.modules["rich.progress"] = progress_stub
+
+rich_table = types.ModuleType("rich.table")
+class Table:
+    def __init__(self, *args, **kwargs):
+        pass
+    def add_column(self, *args, **kwargs):
+        pass
+    def add_row(self, *args, **kwargs):
+        pass
+rich_table.Table = Table
+sys.modules["rich.table"] = rich_table
+
+rich_text = types.ModuleType("rich.text")
+class Text:
+    def __init__(self, *args, **kwargs):
+        pass
+rich_text.Text = Text
+sys.modules["rich.text"] = rich_text
+
+logging_setup_stub = types.ModuleType("plume_nav_sim.utils.logging_setup")
+def get_logger(name):
+    return logging.getLogger(name)
+
+def debug_command_timer(*args, **kwargs):
+    class Dummy:
+        def __enter__(self):
+            return {}
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    return Dummy()
+
+def log_debug_command_correlation(*args, **kwargs):
+    pass
+
+logging_setup_stub.get_logger = get_logger
+logging_setup_stub.debug_command_timer = debug_command_timer
+logging_setup_stub.log_debug_command_correlation = log_debug_command_correlation
+sys.modules["plume_nav_sim.utils.logging_setup"] = logging_setup_stub
+
+# Stub DebugSession
+debug_gui_stub = types.ModuleType("plume_nav_sim.debug.gui")
+class DebugSession:
+    def __init__(self):
+        self.session_id = "dummy"
+    def configure(self, **kwargs):
+        pass
+    def start(self):
+        pass
+    def get_session_info(self):
+        return {}
+debug_gui_stub.DebugSession = DebugSession
+sys.modules["plume_nav_sim.debug.gui"] = debug_gui_stub
+
+# Load CLI module directly
+CLI_PATH = Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim" / "debug" / "cli.py"
+spec = importlib.util.spec_from_file_location("debug_cli", CLI_PATH)
+debug_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(debug_cli)
+
+
+def test_launch_viewer_no_backends_auto(monkeypatch, mock_cli_runner):
+    """Launching viewer with --backend auto and no GUI backends should error."""
+    runner, env = mock_cli_runner
+    if runner is None:
+        pytest.skip("CliRunner not available")
+
+    monkeypatch.setattr(debug_cli, "detect_available_backends", lambda: set())
+
+    with runner.isolated_filesystem():
+        Path("results.json").write_text("{}")
+        result = runner.invoke(
+            debug_cli.debug_group,
+            ["launch-viewer", "--results", "results.json"],
+            env=env,
+        )
+    assert result.exit_code != 0
+    assert "No GUI backends available" in result.output
+
+
+def test_launch_viewer_backend_unavailable(monkeypatch, mock_cli_runner):
+    """Explicit backend request should raise when backend unavailable."""
+    runner, env = mock_cli_runner
+    if runner is None:
+        pytest.skip("CliRunner not available")
+
+    monkeypatch.setattr(debug_cli, "detect_available_backends", lambda: set())
+
+    with runner.isolated_filesystem():
+        Path("results.json").write_text("{}")
+        result = runner.invoke(
+            debug_cli.debug_group,
+            ["launch-viewer", "--backend", "qt", "--results", "results.json"],
+            env=env,
+        )
+    assert result.exit_code != 0
+    assert "Backend 'qt' is not available" in result.output


### PR DESCRIPTION
## Summary
- detect GUI backends and return an empty set when none are available
- raise descriptive errors when requested or auto-selected backend is unavailable
- cover backend availability error paths with tests

## Testing
- `pytest tests/debug/test_debug_cli_backends.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b869ee25bc8320826be1f608f68941