### PR TITLE
Ensure model listings rely on registry contents

### DIFF
--- a/src/plume_nav_sim/models/__init__.py
+++ b/src/plume_nav_sim/models/__init__.py
@@ -648,18 +648,9 @@ def list_available_plume_models() -> List[str]:
         >>> models = list_available_plume_models()
         >>> print(f"Available plume models: {models}")
     """
-    available_models = list(_PLUME_MODEL_REGISTRY.keys())
-    
-    # Add fallback models that have direct import support
-    fallback_models = ['GaussianPlumeModel', 'TurbulentPlumeModel', 'VideoPlumeAdapter']
-    for model in fallback_models:
-        if model not in available_models:
-            # Check if import status indicates availability
-            status = _IMPORT_STATUS['plume_models'].get(model, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_models.append(model)
-    
-    return sorted(available_models)
+    models = sorted(_PLUME_MODEL_REGISTRY.keys())
+    logger.debug("Listing plume models", registry=models)
+    return models
 
 
 def list_available_wind_fields() -> List[str]:
@@ -669,16 +660,9 @@ def list_available_wind_fields() -> List[str]:
     Returns:
         List[str]: List of wind field type names that can be instantiated
     """
-    available_fields = list(_WIND_FIELD_REGISTRY.keys())
-    
-    fallback_fields = ['ConstantWindField', 'TurbulentWindField', 'TimeVaryingWindField']
-    for field in fallback_fields:
-        if field not in available_fields:
-            status = _IMPORT_STATUS['wind_fields'].get(field, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_fields.append(field)
-    
-    return sorted(available_fields)
+    fields = sorted(_WIND_FIELD_REGISTRY.keys())
+    logger.debug("Listing wind fields", registry=fields)
+    return fields
 
 
 def list_available_sensors() -> List[str]:
@@ -688,16 +672,9 @@ def list_available_sensors() -> List[str]:
     Returns:
         List[str]: List of sensor type names that can be instantiated
     """
-    available_sensors = list(_SENSOR_REGISTRY.keys())
-    
-    fallback_sensors = ['BinarySensor', 'ConcentrationSensor', 'GradientSensor']
-    for sensor in fallback_sensors:
-        if sensor not in available_sensors:
-            status = _IMPORT_STATUS['sensors'].get(sensor, {})
-            if not status.get('attempted_import', False) or status.get('available', False):
-                available_sensors.append(sensor)
-    
-    return sorted(available_sensors)
+    sensors = sorted(_SENSOR_REGISTRY.keys())
+    logger.debug("Listing sensors", registry=sensors)
+    return sensors
 
 
 def get_model_registry() -> Dict[str, Dict[str, Any]]:
@@ -713,12 +690,18 @@ def get_model_registry() -> Dict[str, Dict[str, Any]]:
         >>> for model_type, models in registry.items():
         ...     print(f"{model_type}: {list(models.keys())}")
     """
-    return {
+    registry = {
         'plume_models': _PLUME_MODEL_REGISTRY.copy(),
         'wind_fields': _WIND_FIELD_REGISTRY.copy(),
         'sensors': _SENSOR_REGISTRY.copy(),
         'import_status': _IMPORT_STATUS.copy()
     }
+    logger.debug("Returning full model registry", registry_contents={
+        'plume_models': list(_PLUME_MODEL_REGISTRY.keys()),
+        'wind_fields': list(_WIND_FIELD_REGISTRY.keys()),
+        'sensors': list(_SENSOR_REGISTRY.keys())
+    })
+    return registry
 
 
 def validate_protocol_compliance(

--- a/tests/models/test_registry_listings.py
+++ b/tests/models/test_registry_listings.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_models_module():
+    pkg_name = "plume_nav_sim"
+    models_name = f"{pkg_name}.models"
+
+    # Remove existing modules
+    for name in list(sys.modules):
+        if name.startswith(pkg_name):
+            del sys.modules[name]
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src/plume_nav_sim")]
+    sys.modules[pkg_name] = pkg
+
+    # Stub protocols module to satisfy imports
+    core = types.ModuleType(f"{pkg_name}.core")
+    protocols = types.ModuleType(f"{pkg_name}.core.protocols")
+    class _P:
+        pass
+    protocols.PlumeModelProtocol = _P
+    protocols.WindFieldProtocol = _P
+    protocols.SensorProtocol = _P
+    protocols.ComponentConfigType = dict
+    sys.modules[f"{pkg_name}.core"] = core
+    sys.modules[f"{pkg_name}.core.protocols"] = protocols
+
+    path = Path(__file__).resolve().parents[2] / "src/plume_nav_sim/models/__init__.py"
+    spec = importlib.util.spec_from_file_location(models_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[models_name] = module
+    return module
+
+
+def test_listing_functions_only_show_registered_components():
+    mod = load_models_module()
+
+    assert mod.list_available_plume_models() == []
+    assert mod.list_available_wind_fields() == []
+    assert mod.list_available_sensors() == []
+
+    class DummyPlume:
+        pass
+
+    class DummyWind:
+        pass
+
+    class DummySensor:
+        pass
+
+    mod.register_plume_model('DummyPlume', DummyPlume, 'dummy plume')
+    mod.register_wind_field('DummyWind', DummyWind, 'dummy wind')
+    mod.register_sensor('DummySensor', DummySensor, 'dummy sensor')
+
+    assert mod.list_available_plume_models() == ['DummyPlume']
+    assert mod.list_available_wind_fields() == ['DummyWind']
+    assert mod.list_available_sensors() == ['DummySensor']


### PR DESCRIPTION
## Summary
- remove fallback entries from model, wind field, and sensor listings
- log registry contents when listing or inspecting models
- add tests verifying only registered components appear in listings

## Testing
- `pytest tests/models/test_registry_listings.py -q`
- `pytest tests/models -q` *(fails: ImportError: cannot import name 'instantiate' from 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_68b86a1ac1808320a7c5f2efbfff3b21