### PR TITLE
fix: provide base sensor configuration schema

### DIFF
--- a/src/plume_nav_sim/config/schemas.py
+++ b/src/plume_nav_sim/config/schemas.py
@@ -52,6 +52,21 @@ def _validate_orientation_value(value: float, index: Optional[int] = None) -> fl
     return value
 
 
+class SensorConfig(BaseModel):
+    """Generic configuration for sensor components.
+
+    Provides a minimal schema so modules can validate that sensor
+    configuration structures are present. Additional parameters are
+    permitted to support specialized sensor implementations.
+    """
+
+    type: str = Field(..., description="Identifier for the sensor type")
+    params: Dict[str, Any] = Field(
+        default_factory=dict, description="Implementation specific parameters"
+    )
+
+    model_config = ConfigDict(extra="allow")
+
 class SingleAgentConfig(BaseModel):
     """Configuration for single agent navigator."""
     position: Optional[Tuple[float, float]] = None

--- a/src/plume_nav_sim/core/sensors/base_sensor.py
+++ b/src/plume_nav_sim/core/sensors/base_sensor.py
@@ -100,7 +100,7 @@ except ImportError:
 
 # Configuration schemas - fail fast when they are missing
 try:
-    from ...config.schemas import SensorConfig, BinarySensorConfig, ConcentrationSensorConfig
+    from ...config.schemas import SensorConfig
     SCHEMAS_AVAILABLE = True
 except ImportError as exc:  # pragma: no cover - executed only when schemas are absent
     logger.error(
@@ -108,7 +108,7 @@ except ImportError as exc:  # pragma: no cover - executed only when schemas are 
     )
     raise ImportError(
         "Required configuration schemas are missing. Ensure ``plume_nav_sim.config.schemas`` "
-        "defines `SensorConfig`, `BinarySensorConfig`, and `ConcentrationSensorConfig`."
+        "defines `SensorConfig`."
     ) from exc
 
 # PSUtil for memory monitoring (optional dependency)


### PR DESCRIPTION
## Summary
- add minimal `SensorConfig` schema for sensors
- simplify base sensor imports to rely on new schema

## Testing
- `pytest tests/sensors/test_config_schema_presence.py -q`
- `pytest tests/sensors/test_gradient_sensor_dependencies.py -q`
- `pytest tests/core/test_sensors.py::test_direct_odor_sensor_interface -q` *(fails: Input class 'SeedConfig' is not a structured config)*


------
https://chatgpt.com/codex/tasks/task_e_68b8a180d72883209f3de849538145f8