### PR TITLE
refactor(envs): remove fallback components

### DIFF
--- a/tests/environments/test_env_dependency_imports.py
+++ b/tests/environments/test_env_dependency_imports.py
@@ -1,0 +1,30 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+try:  # pragma: no cover - skip if package cannot import
+    import plume_nav_sim  # noqa: F401
+except Exception:  # pragma: no cover
+    pytest.skip("plume_nav_sim import failed", allow_module_level=True)
+
+
+@pytest.mark.parametrize("missing_module", [
+    "plume_nav_sim.models.plume.gaussian_plume",
+    "plume_nav_sim.core.sensors.binary_sensor",
+])
+def test_plume_navigation_env_import_error_missing_dependency(monkeypatch, missing_module):
+    """PlumeNavigationEnv import should fail when dependencies are absent."""
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == missing_module:
+            raise ImportError(f"No module named {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("plume_nav_sim.envs.plume_navigation_env", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.envs.plume_navigation_env")


### PR DESCRIPTION
## Summary
- remove fallback imports for plume models, wind fields, sensors, and frame cache
- add informational logs for successful dependency imports
- test that env import raises ImportError when required modules are missing

## Testing
- `pytest tests/environments/test_env_dependency_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8a40109708320acb97770218f6434