### PR TITLE
fix(protocols): defer SpaceFactory import

### DIFF
--- a/src/plume_nav_sim/core/protocols.py
+++ b/src/plume_nav_sim/core/protocols.py
@@ -75,11 +75,13 @@ except ImportError as e:
     ) from e
 
 try:
-    from ..envs.spaces import SpaceFactory
+    from ..envs.spaces import SpaceFactory  # type: ignore
+    SPACE_FACTORY_AVAILABLE = True
     logger.info("SpaceFactory successfully imported")
-except ImportError as e:
-    logger.error("SpaceFactory is required", exc_info=e)
-    raise ImportError("SpaceFactory is required for plume_nav_sim.core.protocols") from e
+except ImportError as e:  # pragma: no cover - import error path
+    SPACE_FACTORY_AVAILABLE = False
+    SpaceFactory = None  # type: ignore
+    logger.error("SpaceFactory import failed", exc_info=e)
 
 
 @runtime_checkable
@@ -2647,7 +2649,13 @@ class NavigatorFactory:
         """
         if not GYMNASIUM_AVAILABLE:
             return None
-            
+
+        if not SPACE_FACTORY_AVAILABLE or SpaceFactory is None:
+            logger.error("SpaceFactory is required for observation space creation")
+            raise ImportError(
+                "SpaceFactory is required for NavigatorFactory.create_observation_space"
+            )
+
         return SpaceFactory.create_observation_space(
             num_agents=navigator.num_agents,
             include_additional_obs=include_additional_obs,
@@ -2680,7 +2688,13 @@ class NavigatorFactory:
         """
         if not GYMNASIUM_AVAILABLE:
             return None
-            
+
+        if not SPACE_FACTORY_AVAILABLE or SpaceFactory is None:
+            logger.error("SpaceFactory is required for action space creation")
+            raise ImportError(
+                "SpaceFactory is required for NavigatorFactory.create_action_space"
+            )
+
         return SpaceFactory.create_action_space(
             num_agents=navigator.num_agents,
             **space_kwargs

--- a/tests/test_protocols_spacefactory_missing.py
+++ b/tests/test_protocols_spacefactory_missing.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+def test_protocols_handle_missing_spacefactory(monkeypatch):
+    package_path = Path(__file__).resolve().parents[1] / "src" / "plume_nav_sim"
+
+    fake_pkg = types.ModuleType("plume_nav_sim")
+    fake_pkg.__path__ = [str(package_path)]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", fake_pkg)
+
+    fake_core = types.ModuleType("plume_nav_sim.core")
+    fake_core.__path__ = [str(package_path / "core")]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.core", fake_core)
+
+    fake_envs = types.ModuleType("plume_nav_sim.envs")
+    fake_envs.__path__ = []  # empty path to simulate package without modules
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.envs", fake_envs)
+
+    schemas = types.ModuleType("plume_nav_sim.config.schemas")
+    class NavigatorConfig: ...
+    class SingleAgentConfig: ...
+    class MultiAgentConfig: ...
+    schemas.NavigatorConfig = NavigatorConfig
+    schemas.SingleAgentConfig = SingleAgentConfig
+    schemas.MultiAgentConfig = MultiAgentConfig
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.config.schemas", schemas)
+
+    module_path = package_path / "core" / "protocols.py"
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.core.protocols", module_path)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class DummyNavigator:
+        num_agents = 1
+
+    with pytest.raises(ImportError):
+        module.NavigatorFactory.create_observation_space(DummyNavigator())
+
+    with pytest.raises(ImportError):
+        module.NavigatorFactory.create_action_space(DummyNavigator())


### PR DESCRIPTION
## Summary
- allow `plume_nav_sim.core.protocols` to import without `SpaceFactory`
- raise clear errors when creating spaces if `SpaceFactory` is absent
- add regression test for missing `SpaceFactory`

## Testing
- `pytest tests/test_protocols_spacefactory_missing.py -q`
- `pytest tests/test_protocols_dependency_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a5bf371883208c182e2ad38b5877