### PR TITLE
feat: expand rl dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,9 @@ viz = [
 rl = [
     # Core RL dependencies for Gymnasium API compatibility
     "gymnasium==0.29.*",
-    "stable-baselines3>=2.0.0",
+    "stable-baselines3[extra]>=2.0.0",
+    "tensorboard>=2.11.0",
+    "wandb>=0.16.0",
     "shimmy>=1.0.0",
 ]
 performance = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,5 @@ stable-baselines3[extra]>=2.0.0
 PySide6>=6.0.0
 plotly>=5.17.0
 streamlit>=1.0.0
+tensorboard>=2.11.0
+wandb>=0.16.0


### PR DESCRIPTION
## Summary
- widen RL optional dependencies to include tensorboard and wandb
- expose tensorboard and wandb in dev requirements

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0.0 (from versions: none))*
- `pip check`
- `pytest -q` *(fails: ImportError: SpaceFactory is required for plume_nav_sim.core.protocols)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a636f13c832083aba291e28b17d5