### PR TITLE
refactor(cli): simplify initialization and drop availability checks

### DIFF
--- a/tests/cli/test_cli_init_exports.py
+++ b/tests/cli/test_cli_init_exports.py
@@ -1,0 +1,6 @@
+import pathlib
+
+
+def test_cli_init_has_no_is_available_definition():
+    contents = pathlib.Path('src/plume_nav_sim/cli/__init__.py').read_text()
+    assert 'def is_available' not in contents

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -96,7 +96,6 @@ from plume_nav_sim.cli import (
     CLIError as cli_CLIError,
     ConfigValidationError as cli_ConfigValidationError,
     get_version,
-    is_available,
     validate_environment,
     register_command,
     list_commands
@@ -156,7 +155,6 @@ class TestCLIImportValidation:
         """Validate that CLI module utilities are imported from correct locations."""
         cli_module_imports = {
             'get_version': get_version,
-            'is_available': is_available,
             'validate_environment': validate_environment,
             'register_command': register_command
         }
@@ -1380,14 +1378,6 @@ class TestCLIUtilityFunctions:
         version = get_version()
         assert isinstance(version, str)
         assert len(version) > 0
-
-    def test_cli_availability_check(self):
-        """Test CLI availability checking."""
-        available = is_available()
-        assert isinstance(available, bool)
-        
-        # Should be True since we're running CLI tests
-        assert available is True
 
     def test_cli_environment_validation(self):
         """Test CLI environment validation."""


### PR DESCRIPTION
## Summary
- import version and CLI components directly with debug logging
- remove legacy is_available checks and related status tracking
- adjust tests to match streamlined CLI surface

## Testing
- `pytest tests/cli/test_cli_init_exports.py -q`
- `pytest tests/cli/test_cli_main.py::TestCLIImportValidation::test_cli_init_imports -q` *(fails: Input class 'SeedConfig' is not a structured config. did you forget to decorate it as a dataclass?)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a655c80c8320b0c74511352e2b6b