### PR TITLE
refactor(env): remove optional dependency fallbacks

### DIFF
--- a/tests/envs/test_envs_package_dependencies.py
+++ b/tests/envs/test_envs_package_dependencies.py
@@ -8,6 +8,15 @@ MISSING_MODULES = [
     "plume_nav_sim.envs.video_plume",
     "plume_nav_sim.utils.logging_setup",
     "gymnasium",
+    "plume_nav_sim.utils.seed_utils",
+    "plume_nav_sim.hooks",
+    "plume_nav_sim.core.sources",
+    "plume_nav_sim.core.initialization",
+    "plume_nav_sim.core.boundaries",
+    "plume_nav_sim.core.actions",
+    "plume_nav_sim.recording",
+    "plume_nav_sim.analysis",
+    "matplotlib",
 ]
 
 @pytest.mark.parametrize("missing", MISSING_MODULES)

--- a/tests/envs/test_plume_navigation_env_dependencies.py
+++ b/tests/envs/test_plume_navigation_env_dependencies.py
@@ -4,22 +4,50 @@ import types
 import builtins
 import pytest
 
-def test_missing_spaces_module_raises_import_error(monkeypatch):
+MISSING_MODULES = [
+    "plume_nav_sim.envs.spaces",
+    "plume_nav_sim.utils.seed_utils",
+    "plume_nav_sim.hooks",
+    "plume_nav_sim.utils.logging_setup",
+    "omegaconf",
+    "hydra.utils",
+    "plume_nav_sim.core.sources",
+    "plume_nav_sim.core.initialization",
+    "plume_nav_sim.core.boundaries",
+    "plume_nav_sim.core.actions",
+    "plume_nav_sim.recording",
+    "plume_nav_sim.analysis",
+    "matplotlib",
+]
+
+
+@pytest.mark.parametrize("missing", MISSING_MODULES)
+def test_missing_dependency_raises_import_error(monkeypatch, missing):
     module_name = "plume_nav_sim.envs.plume_navigation_env"
     sys.modules.pop(module_name, None)
 
-    # Mock hydra to avoid configuration side effects
-    hydra_module = types.ModuleType("hydra")
-    hydra_utils = types.ModuleType("hydra.utils")
-    hydra_utils.instantiate = lambda cfg, *a, **kw: cfg
-    sys.modules["hydra"] = hydra_module
-    sys.modules["hydra.utils"] = hydra_utils
+    if missing not in {"omegaconf", "hydra.utils"}:
+        hydra_module = types.ModuleType("hydra")
+        hydra_utils = types.ModuleType("hydra.utils")
+        hydra_utils.instantiate = lambda cfg, *a, **kw: cfg
+        sys.modules["hydra"] = hydra_module
+        sys.modules["hydra.utils"] = hydra_utils
+        omegaconf_module = types.ModuleType("omegaconf")
+        class DictConfig(dict):
+            pass
+        class OmegaConf:
+            @staticmethod
+            def to_container(config, resolve=True):
+                return dict(config)
+        omegaconf_module.DictConfig = DictConfig
+        omegaconf_module.OmegaConf = OmegaConf
+        sys.modules["omegaconf"] = omegaconf_module
 
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "plume_nav_sim.envs.spaces":
-            raise ImportError("spaces module missing")
+        if name == missing:
+            raise ImportError(f"{missing} missing")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)


### PR DESCRIPTION
## Summary
- require seed utilities, hooks, logging setup, Hydra, and component factories at import time
- remove optional fallbacks and assume real implementations
- expand dependency tests to assert ImportError when modules are missing

## Testing
- `PYTHONPATH=src pytest tests/envs/test_plume_navigation_env_dependencies.py::test_missing_dependency_raises_import_error -q`
- `PYTHONPATH=src pytest tests/envs/test_envs_package_dependencies.py::test_import_error_when_dependency_missing -q`
- `PYTHONPATH=src pytest -q` *(fails: ImportError: plume_nav_sim.core.controllers could not be imported)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a85c3d4483209b99ea867d4c1f39