### PR TITLE
refactor: rely on gymnasium spaces

### DIFF
--- a/src/odor_plume_nav/environments/gymnasium_env.py
+++ b/src/odor_plume_nav/environments/gymnasium_env.py
@@ -38,18 +38,9 @@ from pathlib import Path
 import numpy as np
 
 # Gymnasium and RL framework imports
-try:
-    import gymnasium as gym
-    from gymnasium.spaces import Box, Dict as DictSpace
-    from gymnasium.error import DependencyNotInstalled
-    GYMNASIUM_AVAILABLE = True
-except ImportError:
-    GYMNASIUM_AVAILABLE = False
-    # Create mock classes to prevent import errors
-    class gym:
-        class Env:
-            def __init__(self): pass
-    Box = DictSpace = None
+import gymnasium as gym
+from gymnasium.spaces import Box, Dict as DictSpace
+from gymnasium.error import DependencyNotInstalled
 
 # Core plume navigation imports
 from odor_plume_nav.core.protocols import NavigatorProtocol, NavigatorFactory
@@ -312,12 +303,6 @@ class GymnasiumEnv(gym.Env):
             When frame_cache is provided, performance metrics including cache hit rates
             and memory utilization are embedded in step() info["perf_stats"] for analysis.
         """
-        if not GYMNASIUM_AVAILABLE:
-            raise ImportError(
-                "gymnasium is required for GymnasiumEnv. "
-                "Install with: pip install 'odor_plume_nav[rl]'"
-            )
-        
         super().__init__()
         
         # Store configuration parameters

--- a/src/odor_plume_nav/rl/policies.py
+++ b/src/odor_plume_nav/rl/policies.py
@@ -56,7 +56,7 @@ except ImportError:
     DictConfig = dict
 
 # Local imports - dependencies analyzed from context
-from odor_plume_nav.environments.spaces import ObservationType, ActionType, GYMNASIUM_AVAILABLE
+from odor_plume_nav.environments.spaces import ObservationType, ActionType
 from odor_plume_nav.config.models import resolve_env_value, validate_env_interpolation
 
 # Enhanced logging

--- a/tests/test_spaces_import.py
+++ b/tests/test_spaces_import.py
@@ -1,0 +1,10 @@
+import importlib.util
+import pathlib
+
+
+def test_spaces_does_not_define_gymnasium_available():
+    module_path = pathlib.Path(__file__).resolve().parents[1] / "src" / "odor_plume_nav" / "environments" / "spaces.py"
+    spec = importlib.util.spec_from_file_location("spaces", module_path)
+    spaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(spaces)
+    assert not hasattr(spaces, "GYMNASIUM_AVAILABLE")


### PR DESCRIPTION
## Summary
- import gymnasium spaces directly and drop GYMNASIUM_AVAILABLE flag
- remove legacy checks in GymnasiumEnv and policies
- add test ensuring spaces module no longer exposes optional flag

## Testing
- `pytest tests/test_spaces_import.py -q`
- `pytest tests/cli/test_cli_main.py::test_no_gymnasium_available_attr -q` *(fails: ImportError: cannot import name 'instantiate' from 'hydra')*


------
https://chatgpt.com/codex/tasks/task_e_68b8c8e8f9008320af695651c9d408ee