### PR TITLE
feat: rely solely on loguru for base sensor

### DIFF
--- a/src/plume_nav_sim/core/sensors/base_sensor.py
+++ b/src/plume_nav_sim/core/sensors/base_sensor.py
@@ -90,13 +90,7 @@ except ImportError:
     OmegaConf = None
 
 # Loguru integration for enhanced logging
-try:
-    from loguru import logger
-    LOGURU_AVAILABLE = True
-except ImportError:
-    import logging
-    logger = logging.getLogger(__name__)
-    LOGURU_AVAILABLE = False
+from loguru import logger
 
 # Configuration schemas - fail fast when they are missing
 try:
@@ -290,7 +284,7 @@ class BaseSensor(ABC):
             self._base_memory_usage = 0
         
         # Setup structured logging with sensor context binding
-        if self._enable_logging and LOGURU_AVAILABLE:
+        if self._enable_logging:
             self._logger = logger.bind(
                 sensor_type=self._sensor_type,
                 sensor_id=self._sensor_id,
@@ -1113,7 +1107,7 @@ def create_sensor_from_config(
             raise ValueError(f"Unknown sensor type: {sensor_type}")
         
     except Exception as e:
-        if enable_logging and LOGURU_AVAILABLE:
+        if enable_logging:
             logger.error(
                 f"Sensor creation failed: {str(e)}",
                 error_type=type(e).__name__,

--- a/tests/sensors/test_base_sensor_loguru_exclusive.py
+++ b/tests/sensors/test_base_sensor_loguru_exclusive.py
@@ -1,0 +1,34 @@
+from loguru import logger as loguru_logger
+import importlib.util
+import pathlib
+import sys
+import types
+
+
+def test_base_sensor_uses_loguru_exclusively():
+    module_path = pathlib.Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'core' / 'sensors' / 'base_sensor.py'
+
+    # Stub package hierarchy to satisfy relative imports without executing package __init__
+    pkg_plume = types.ModuleType('plume_nav_sim'); pkg_plume.__path__ = []
+    pkg_core = types.ModuleType('plume_nav_sim.core'); pkg_core.__path__ = []
+    pkg_core_sensors = types.ModuleType('plume_nav_sim.core.sensors'); pkg_core_sensors.__path__ = []
+    pkg_config = types.ModuleType('plume_nav_sim.config'); pkg_config.__path__ = []
+    pkg_schemas = types.ModuleType('plume_nav_sim.config.schemas'); pkg_schemas.__path__ = []
+    class SensorConfig: ...
+    pkg_schemas.SensorConfig = SensorConfig
+
+    sys.modules.update({
+        'plume_nav_sim': pkg_plume,
+        'plume_nav_sim.core': pkg_core,
+        'plume_nav_sim.core.sensors': pkg_core_sensors,
+        'plume_nav_sim.config': pkg_config,
+        'plume_nav_sim.config.schemas': pkg_schemas,
+    })
+
+    spec = importlib.util.spec_from_file_location('plume_nav_sim.core.sensors.base_sensor', module_path)
+    base_sensor = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = base_sensor
+    spec.loader.exec_module(base_sensor)
+
+    assert base_sensor.logger is loguru_logger
+    assert not hasattr(base_sensor, 'LOGURU_AVAILABLE')


### PR DESCRIPTION
## Summary
- remove conditional loguru import from base sensor
- verify base sensor uses loguru without availability checks

## Testing
- `pytest tests/sensors/test_base_sensor_loguru_exclusive.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8c8ebf79c8320bc2527069f064b63