### PR TITLE
refactor: remove dataclasses fallback in visualization config registration

### DIFF
--- a/src/odor_plume_nav/utils/visualization.py
+++ b/src/odor_plume_nav/utils/visualization.py
@@ -1176,51 +1176,43 @@ def create_static_plotter(
 # Hydra ConfigStore registration for visualization configurations
 if HYDRA_AVAILABLE:
     cs = ConfigStore.instance()
-    
-    # Register visualization configuration schemas
-    try:
-        from dataclasses import dataclass, field
-        from typing import Optional
-        
-        @dataclass
-        class AnimationConfig:
-            fps: int = 30
-            format: str = "mp4"
-            quality: str = "medium"
-            
-        @dataclass  
-        class StaticConfig:
-            dpi: int = 300
-            format: str = "png"
-            figsize: Tuple[float, float] = (12, 8)
-            
-        @dataclass
-        class AgentConfig:
-            max_agents: int = 100
-            color_scheme: str = "scientific"
-            trail_length: int = 1000
-            
-        @dataclass
-        class VisualizationConfig:
-            animation: AnimationConfig = field(default_factory=AnimationConfig)
-            static: StaticConfig = field(default_factory=StaticConfig)
-            agents: AgentConfig = field(default_factory=AgentConfig)
-            headless: bool = False
-            resolution: str = "720p"
-            theme: str = "scientific"
-        
-        # Register configuration groups
-        cs.store(group="visualization", name="animation", node=AnimationConfig)
-        cs.store(group="visualization", name="static", node=StaticConfig)
-        cs.store(group="visualization", name="agents", node=AgentConfig)
-        cs.store(group="visualization", name="base", node=VisualizationConfig)
-        
-        logger.debug("Registered Hydra configuration schemas for visualization")
-        
-    except ImportError:
-        # Fallback if dataclasses not available
-        logger.warning("Dataclasses not available, skipping Hydra ConfigStore registration")
-        pass
+
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class AnimationConfig:
+        fps: int = 30
+        format: str = "mp4"
+        quality: str = "medium"
+
+    @dataclass
+    class StaticConfig:
+        dpi: int = 300
+        format: str = "png"
+        figsize: Tuple[float, float] = (12, 8)
+
+    @dataclass
+    class AgentConfig:
+        max_agents: int = 100
+        color_scheme: str = "scientific"
+        trail_length: int = 1000
+
+    @dataclass
+    class VisualizationConfig:
+        animation: AnimationConfig = field(default_factory=AnimationConfig)
+        static: StaticConfig = field(default_factory=StaticConfig)
+        agents: AgentConfig = field(default_factory=AgentConfig)
+        headless: bool = False
+        resolution: str = "720p"
+        theme: str = "scientific"
+
+    # Register configuration groups
+    cs.store(group="visualization", name="animation", node=AnimationConfig)
+    cs.store(group="visualization", name="static", node=StaticConfig)
+    cs.store(group="visualization", name="agents", node=AgentConfig)
+    cs.store(group="visualization", name="base", node=VisualizationConfig)
+
+    logger.debug("Registered Hydra configuration schemas for visualization")
 
 
 # Public API exports

--- a/src/plume_nav_sim/utils/visualization.py
+++ b/src/plume_nav_sim/utils/visualization.py
@@ -2709,47 +2709,46 @@ def create_static_plotter(
 # Hydra ConfigStore registration for visualization configurations
 cs = ConfigStore.instance()
 
-try:
-    from dataclasses import dataclass, field
-    from typing import Optional
+from dataclasses import dataclass, field
 
-    @dataclass
-    class AnimationConfig:
-        fps: int = 30
-        format: str = "mp4"
-        quality: str = "medium"
 
-    @dataclass
-    class StaticConfig:
-        dpi: int = 300
-        format: str = "png"
-        figsize: Tuple[float, float] = (12, 8)
+@dataclass
+class AnimationConfig:
+    fps: int = 30
+    format: str = "mp4"
+    quality: str = "medium"
 
-    @dataclass
-    class AgentConfig:
-        max_agents: int = 100
-        color_scheme: str = "scientific"
-        trail_length: int = 1000
 
-    @dataclass
-    class VisualizationConfig:
-        animation: AnimationConfig = field(default_factory=AnimationConfig)
-        static: StaticConfig = field(default_factory=StaticConfig)
-        agents: AgentConfig = field(default_factory=AgentConfig)
-        headless: bool = False
-        resolution: str = "720p"
-        theme: str = "scientific"
+@dataclass
+class StaticConfig:
+    dpi: int = 300
+    format: str = "png"
+    figsize: Tuple[float, float] = (12, 8)
 
-    cs.store(group="visualization", name="animation", node=AnimationConfig)
-    cs.store(group="visualization", name="static", node=StaticConfig)
-    cs.store(group="visualization", name="agents", node=AgentConfig)
-    cs.store(group="visualization", name="base", node=VisualizationConfig)
 
-    logger.debug("Registered Hydra configuration schemas for visualization")
+@dataclass
+class AgentConfig:
+    max_agents: int = 100
+    color_scheme: str = "scientific"
+    trail_length: int = 1000
 
-except ImportError:
-    logger.warning("Dataclasses not available, skipping Hydra ConfigStore registration")
-    pass
+
+@dataclass
+class VisualizationConfig:
+    animation: AnimationConfig = field(default_factory=AnimationConfig)
+    static: StaticConfig = field(default_factory=StaticConfig)
+    agents: AgentConfig = field(default_factory=AgentConfig)
+    headless: bool = False
+    resolution: str = "720p"
+    theme: str = "scientific"
+
+
+cs.store(group="visualization", name="animation", node=AnimationConfig)
+cs.store(group="visualization", name="static", node=StaticConfig)
+cs.store(group="visualization", name="agents", node=AgentConfig)
+cs.store(group="visualization", name="base", node=VisualizationConfig)
+
+logger.debug("Registered Hydra configuration schemas for visualization")
 
 
 # Public API exports

--- a/tests/visualization/test_visualization_dataclasses.py
+++ b/tests/visualization/test_visualization_dataclasses.py
@@ -1,0 +1,31 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "plume_nav_sim.utils.visualization",
+        "odor_plume_nav.utils.visualization",
+    ],
+)
+def test_visualization_requires_dataclasses(monkeypatch, module_path):
+    """Importing visualization modules should require dataclasses."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "dataclasses":
+            raise ImportError("mock missing dataclasses")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "dataclasses", raising=False)
+
+    if module_path in sys.modules:
+        del sys.modules[module_path]
+
+    with pytest.raises(ImportError):
+        importlib.import_module(module_path)


### PR DESCRIPTION
## Summary
- drop try/except around dataclass-based visualization configs
- verify visualization modules error when dataclasses are missing

## Testing
- `pytest tests/visualization/test_visualization_dataclasses.py::test_visualization_requires_dataclasses -q`
- `pytest tests/visualization/test_trajectory.py::TestVisualizationModuleIntegration::test_unified_import_structure -q` *(fails: cannot import name 'instantiate' from 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c8ed4c908320a234038751920539