### PR TITLE
fix: raise on gymnasium registration failure

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -132,70 +132,61 @@ def _register_gymnasium_environments():
     Registers both the primary PlumeNavSim-v0 environment and the legacy
     OdorPlumeNavigation-v1 environment for backward compatibility.
     """
-    try:
-        import gymnasium
-        from gymnasium.envs.registration import register
+    import gymnasium
+    from gymnasium.envs.registration import register
 
-        env_kwargs = {
-            'api_version': 'gymnasium',
-            'return_format': '5-tuple',
-            'enable_extensibility_hooks': True,
+    env_kwargs = {
+        'api_version': 'gymnasium',
+        'return_format': '5-tuple',
+        'enable_extensibility_hooks': True,
+    }
+
+    # Register primary Gymnasium environment
+    register(
+        id='PlumeNavSim-v0',
+        entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
+        max_episode_steps=1000,
+        reward_threshold=500.0,
+        kwargs=dict(env_kwargs),
+    )
+    logger.info(
+        "Registered PlumeNavSim-v0 environment",
+        extra={"metric_type": "environment_registration", "env_id": "PlumeNavSim-v0"},
+    )
+
+    # Register snake_case alias
+    register(
+        id='plume_nav_sim_v0',
+        entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
+        max_episode_steps=1000,
+        reward_threshold=500.0,
+        kwargs=dict(env_kwargs),
+    )
+    logger.info(
+        "Registered plume_nav_sim_v0 alias for PlumeNavSim-v0",
+        extra={
+            "metric_type": "environment_registration",
+            "env_id": "plume_nav_sim_v0",
+            "alias_for": "PlumeNavSim-v0",
+        },
+    )
+
+    # Register legacy compatibility environment
+    register(
+        id='OdorPlumeNavigation-v1',
+        entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
+        max_episode_steps=1000,
+        reward_threshold=500.0,
+        kwargs={
+            'api_version': 'legacy',
+            'return_format': '4-tuple',
+            'enable_extensibility_hooks': False,
         }
-
-        # Register primary Gymnasium environment
-        register(
-            id='PlumeNavSim-v0',
-            entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
-            max_episode_steps=1000,
-            reward_threshold=500.0,
-            kwargs=dict(env_kwargs),
-        )
-        logger.info(
-            "Registered PlumeNavSim-v0 environment",
-            extra={"metric_type": "environment_registration", "env_id": "PlumeNavSim-v0"},
-        )
-
-        # Register snake_case alias
-        register(
-            id='plume_nav_sim_v0',
-            entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
-            max_episode_steps=1000,
-            reward_threshold=500.0,
-            kwargs=dict(env_kwargs),
-        )
-        logger.info(
-            "Registered plume_nav_sim_v0 alias for PlumeNavSim-v0",
-            extra={
-                "metric_type": "environment_registration",
-                "env_id": "plume_nav_sim_v0",
-                "alias_for": "PlumeNavSim-v0",
-            },
-        )
-
-        # Register legacy compatibility environment
-        register(
-            id='OdorPlumeNavigation-v1',
-            entry_point='plume_nav_sim.envs:PlumeNavigationEnv',
-            max_episode_steps=1000,
-            reward_threshold=500.0,
-            kwargs={
-                'api_version': 'legacy',
-                'return_format': '4-tuple',
-                'enable_extensibility_hooks': False,
-            }
-        )
-
-        return True
-        
-    except ImportError:
-        # Gymnasium not available - environments will not be registered
-        return False
-    except Exception:
-        # Registration failed - continue without breaking package import
-        return False
+    )
 
 # Attempt environment registration
-_gymnasium_registered = _register_gymnasium_environments()
+_register_gymnasium_environments()
+_gymnasium_registered = True
 
 # =============================================================================
 # CONDITIONAL IMPORTS AND API EXPORTS

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -19,3 +19,37 @@ def test_import_fails_when_core_unavailable(monkeypatch):
 
     with pytest.raises(ImportError):
         import plume_nav_sim  # noqa: F401
+
+
+def test_import_fails_without_gymnasium(monkeypatch):
+    for mod in list(sys.modules):
+        if mod.startswith("plume_nav_sim"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "gymnasium":
+            raise ImportError("gymnasium missing")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        import plume_nav_sim  # noqa: F401
+
+
+def test_import_fails_on_registration_error(monkeypatch):
+    for mod in list(sys.modules):
+        if mod.startswith("plume_nav_sim"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    import gymnasium
+
+    def bad_register(*args, **kwargs):
+        raise RuntimeError("registration failed")
+
+    monkeypatch.setattr(gymnasium.envs.registration, "register", bad_register)
+
+    with pytest.raises(RuntimeError):
+        import plume_nav_sim  # noqa: F401


### PR DESCRIPTION
## Summary
- remove error suppression when registering Gymnasium environments
- add import-time tests for missing Gymnasium and registration failures

## Testing
- `pytest tests/test_package_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c8ee44d483208dfa02d78046ac44