### PR TITLE
refactor: remove optional navigator utils dependencies

### DIFF
--- a/tests/utils/test_navigator_utils_flags.py
+++ b/tests/utils/test_navigator_utils_flags.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'utils' / 'navigator_utils.py'
+source = module_path.read_text()
+
+
+def test_no_availability_flags():
+    assert 'SEED_MANAGER_AVAILABLE' not in source
+    assert 'ENHANCED_LOGGING_AVAILABLE' not in source
+    assert 'HYDRA_AVAILABLE' not in source


### PR DESCRIPTION
## Summary
- drop HYDRA/seed-manager/logging availability flags in navigator utilities
- use enhanced logger and seed manager directly
- test that navigator_utils.py contains no availability flags

## Testing
- `pytest tests/utils/test_navigator_utils_flags.py::test_no_availability_flags -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8e0124084832086a8181a920d890d