### PR TITLE
test: require pandas for initialization import test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 numpy>=1.26.0
+pandas>=1.5.0
 gymnasium==0.29.*
 matplotlib>=3.7.0
 opencv-python-headless>=4.8.0

--- a/src/plume_nav_sim/tests/test_initialization_import.py
+++ b/src/plume_nav_sim/tests/test_initialization_import.py
@@ -2,15 +2,13 @@ import importlib
 import logging
 import builtins
 import sys
-import types
 
 import pytest
 
+pandas = pytest.importorskip("pandas")
 
-def test_agent_initializer_protocol_import_logs_success(caplog, monkeypatch):
-    # Provide minimal pandas stub to satisfy import
-    monkeypatch.setitem(sys.modules, 'pandas', types.ModuleType('pandas'))
 
+def test_agent_initializer_protocol_import_logs_success(caplog):
     caplog.set_level(logging.INFO)
     import plume_nav_sim.core.initialization as init
     importlib.reload(init)
@@ -18,8 +16,6 @@ def test_agent_initializer_protocol_import_logs_success(caplog, monkeypatch):
 
 
 def test_missing_protocols_raises_import_error(monkeypatch):
-    monkeypatch.setitem(sys.modules, 'pandas', types.ModuleType('pandas'))
-
     original_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):


### PR DESCRIPTION
## Summary
- use real pandas in initialization import tests and remove monkeypatch
- skip tests when pandas is unavailable
- document pandas dependency for tests

## Testing
- `pytest src/plume_nav_sim/tests/test_initialization_import.py -q` *(fails: plume_nav_sim.core.controllers could not be imported)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e2a3229c83208e9ee410dc5bdce7