### PR TITLE
refactor: drop legacy io_utils alias

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## Unreleased
+
+- Removed legacy `plume_nav_sim.io_utils` alias. Import utilities from `plume_nav_sim.utils.io`.

--- a/plume_nav_sim.txt
+++ b/plume_nav_sim.txt
@@ -2978,10 +2978,9 @@ import yaml
 import json
 import numpy as np
 
-# Import from the existing io_utils module for now
-# This will be refactored in a future update
+# Import from the current plume_nav_sim implementation
 try:
-    from odor_plume_nav.io_utils import (
+    from plume_nav_sim.utils.io import (
         load_yaml,
         save_yaml,
         load_json,

--- a/src/odor_plume_nav/utils/io.py
+++ b/src/odor_plume_nav/utils/io.py
@@ -10,10 +10,9 @@ import yaml
 import json
 import numpy as np
 
-# Import from the existing io_utils module for now
-# This will be refactored in a future update
+# Import from the current plume_nav_sim implementation
 try:
-    from odor_plume_nav.io_utils import (
+    from plume_nav_sim.utils.io import (
         load_yaml,
         save_yaml,
         load_json,

--- a/src/plume_nav_sim/utils/io.py
+++ b/src/plume_nav_sim/utils/io.py
@@ -419,30 +419,3 @@ def save_numpy(
             pass
         raise NumpyError(f"Failed to serialize NumPy array: {e}") from e
 
-
-# Maintain backward compatibility with legacy io_utils imports
-# This provides a fallback for projects that may still import from the old structure
-def _setup_legacy_compatibility() -> None:
-    """
-    Set up compatibility with legacy io_utils module imports.
-    
-    This function attempts to make the current module's functions available
-    through legacy import paths for backward compatibility during the migration.
-    """
-    try:
-        import sys
-        current_module = sys.modules[__name__]
-        
-        # Try to make functions available through legacy paths if needed
-        # This helps during the transition period
-        if 'plume_nav_sim.io_utils' not in sys.modules:
-            sys.modules['plume_nav_sim.io_utils'] = current_module
-            
-    except Exception:
-        # If compatibility setup fails, continue without it
-        # This is not critical to core functionality
-        pass
-
-
-# Initialize backward compatibility on import
-_setup_legacy_compatibility()

--- a/tests/test_io_legacy_alias_removed.py
+++ b/tests/test_io_legacy_alias_removed.py
@@ -1,0 +1,23 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_io_module():
+    module_name = "plume_nav_sim.utils.io"
+    module_path = Path(__file__).resolve().parents[1] / "src/plume_nav_sim/utils/io.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("plume_nav_sim", types.ModuleType("plume_nav_sim"))
+    pkg_utils = types.ModuleType("plume_nav_sim.utils")
+    pkg_utils.__path__ = []
+    sys.modules.setdefault("plume_nav_sim.utils", pkg_utils)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_legacy_io_utils_import_removed():
+    _load_io_module()
+    assert "plume_nav_sim.io_utils" not in sys.modules


### PR DESCRIPTION
## Summary
- remove `_setup_legacy_compatibility` shim from I/O utilities
- route legacy `odor_plume_nav.utils.io` module through `plume_nav_sim.utils.io`
- document removal of `plume_nav_sim.io_utils` alias

## Testing
- `pytest tests/test_io_legacy_alias_removed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e2a2355c83209c337457b4d58e26