### PR TITLE
refactor: enforce explicit imports in navigator utilities

### DIFF
--- a/src/plume_nav_sim/utils/navigator_utils.py
+++ b/src/plume_nav_sim/utils/navigator_utils.py
@@ -34,39 +34,27 @@ from dataclasses import dataclass, field
 import time
 import threading
 from pathlib import Path
-import logging
 
-logger = logging.getLogger(__name__)
+from plume_nav_sim.utils.logging_setup import get_enhanced_logger
 
-try:
-    from plume_nav_sim.protocols.navigator import NavigatorProtocol
-    from plume_nav_sim.core.navigator import Navigator
-except ImportError as exc:
-    logger.exception("Failed to import navigator dependencies: %s", exc)
-    raise
+logger = get_enhanced_logger(__name__)
 
-try:
-    from plume_nav_sim.config.models import (
-        NavigatorConfig,
-        SingleAgentConfig,
-        MultiAgentConfig,
-    )
-except ImportError as exc:
-    logger.exception("Failed to import configuration models: %s", exc)
-    raise
-
-# Hydra is required for configuration management
+from plume_nav_sim.protocols.navigator import NavigatorProtocol
+from plume_nav_sim.core.navigator import Navigator
+from plume_nav_sim.config.models import (
+    NavigatorConfig,
+    SingleAgentConfig,
+    MultiAgentConfig,
+)
 from omegaconf import DictConfig, OmegaConf
 from hydra.core.hydra_config import HydraConfig
-
 from plume_nav_sim.utils.seed_manager import (
     SeedManager,
     set_global_seed,
     get_global_seed_manager,
 )
-from plume_nav_sim.utils.logging_setup import get_enhanced_logger
 
-logger = get_enhanced_logger(__name__)
+logger.info("Navigator utilities dependencies initialized")
 
 
 # A dictionary of *base* local sensor offsets (in arbitrary units).

--- a/tests/utils/test_navigator_utils_imports.py
+++ b/tests/utils/test_navigator_utils_imports.py
@@ -1,6 +1,9 @@
 import importlib
 import builtins
+import logging
 import sys
+from pathlib import Path
+import types
 
 import pytest
 
@@ -37,3 +40,96 @@ def test_import_fails_without_config_models(monkeypatch):
 
     with pytest.raises(ImportError):
         importlib.import_module(MODULE_PATH)
+
+
+def test_import_fails_without_hydra(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {'omegaconf', 'hydra.core.hydra_config'}:
+            raise ImportError('Hydra missing')
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.delitem(sys.modules, MODULE_PATH, raising=False)
+    monkeypatch.delitem(sys.modules, 'omegaconf', raising=False)
+    monkeypatch.delitem(sys.modules, 'hydra.core.hydra_config', raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(MODULE_PATH)
+
+
+def test_import_fails_without_logging_utils(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'plume_nav_sim.utils.logging_setup':
+            raise ImportError('Logging setup missing')
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.delitem(sys.modules, MODULE_PATH, raising=False)
+    monkeypatch.delitem(sys.modules, 'plume_nav_sim.utils.logging_setup', raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(MODULE_PATH)
+
+
+def test_logs_successful_dependency_initialization(monkeypatch, caplog):
+    package_path = Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim'
+
+    fake_pkg = types.ModuleType('plume_nav_sim')
+    fake_pkg.__path__ = [str(package_path)]
+    monkeypatch.setitem(sys.modules, 'plume_nav_sim', fake_pkg)
+
+    fake_utils_pkg = types.ModuleType('plume_nav_sim.utils')
+    fake_utils_pkg.__path__ = [str(package_path / 'utils')]
+    monkeypatch.setitem(sys.modules, 'plume_nav_sim.utils', fake_utils_pkg)
+
+    monkeypatch.setitem(
+        sys.modules,
+        'plume_nav_sim.protocols.navigator',
+        types.SimpleNamespace(NavigatorProtocol=object),
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        'plume_nav_sim.core.navigator',
+        types.SimpleNamespace(Navigator=object),
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        'plume_nav_sim.config.models',
+        types.SimpleNamespace(
+            NavigatorConfig=object,
+            SingleAgentConfig=object,
+            MultiAgentConfig=object,
+        ),
+    )
+
+    def get_enhanced_logger(name):
+        return logging.getLogger(name)
+
+    monkeypatch.setitem(
+        sys.modules,
+        'plume_nav_sim.utils.logging_setup',
+        types.SimpleNamespace(get_enhanced_logger=get_enhanced_logger),
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        'plume_nav_sim.utils.seed_manager',
+        types.SimpleNamespace(
+            SeedManager=object,
+            set_global_seed=lambda *a, **k: None,
+            get_global_seed_manager=lambda: None,
+        ),
+    )
+
+    module_file = package_path / 'utils' / 'navigator_utils.py'
+    top_lines = ''.join(module_file.read_text().splitlines(keepends=True)[:170])
+    with caplog.at_level(logging.INFO):
+        exec(compile(top_lines, str(module_file), 'exec'), {})
+
+    assert 'Navigator utilities dependencies initialized' in caplog.text


### PR DESCRIPTION
## Summary
- remove implicit dependency flags and logging fallbacks from navigator utilities
- ensure imports of Hydra and logging utilities raise on failure
- add tests for missing dependencies and successful initialization logging

## Testing
- `pytest tests/utils/test_navigator_utils_imports.py -q`
- `pytest tests/utils/test_navigator_utils_flags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e2a12d7883209700fd0d748fbc2b