### PR TITLE
feat: require hydra and numba

### DIFF
--- a/src/plume_nav_sim/models/wind/turbulent_wind.py
+++ b/src/plume_nav_sim/models/wind/turbulent_wind.py
@@ -1,9 +1,9 @@
 """
 TurbulentWindField: Realistic gusty wind conditions with stochastic variations and atmospheric boundary layer dynamics.
 
-This module implements a high-fidelity turbulent wind field model using statistical modeling 
-of atmospheric boundary layer dynamics, complex eddy formations, and stochastic wind patterns. 
-The implementation provides research-grade environmental realism for studying plume navigation 
+This module implements a high-fidelity turbulent wind field model using statistical modeling
+of atmospheric boundary layer dynamics, complex eddy formations, and stochastic wind patterns.
+The implementation provides research-grade environmental realism for studying plume navigation
 while maintaining performance requirements for real-time simulation.
 
 Key Features:
@@ -38,12 +38,12 @@ Example Usage:
     ... )
     >>> agent_positions = np.array([[25, 30], [35, 45]])
     >>> wind_velocities = turbulent_wind.velocity_at(agent_positions)
-    
+
     Temporal wind field evolution:
     >>> for t in range(100):
     ...     turbulent_wind.step(dt=1.0)
     ...     current_velocities = turbulent_wind.velocity_at(agent_positions)
-    
+
     Configuration-driven instantiation:
     >>> from hydra import compose, initialize
     >>> with initialize(config_path="../conf"):
@@ -59,11 +59,17 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
+# Logging imports
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Scientific computing imports
 try:
     import scipy.stats
     from scipy.spatial.distance import cdist
     from scipy.interpolate import griddata, RBFInterpolator
+
     SCIPY_AVAILABLE = True
 except ImportError:
     SCIPY_AVAILABLE = False
@@ -71,59 +77,37 @@ except ImportError:
         "SciPy not available. Turbulent wind modeling will use simplified algorithms. "
         "Install scipy>=1.9.0 for full turbulent wind field support.",
         UserWarning,
-        stacklevel=2
+        stacklevel=2,
     )
 
-# Optional Numba imports for JIT acceleration
-try:
-    import numba
-    from numba import jit, prange
-    NUMBA_AVAILABLE = True
-    
-    # Numba compilation settings for performance optimization
-    NUMBA_OPTIONS = {
-        'nopython': True,
-        'fastmath': True,
-        'cache': True,
-        'parallel': True
-    }
-except ImportError:
-    NUMBA_AVAILABLE = False
-    
-    # Dummy decorator when Numba is not available
-    def jit(*args, **kwargs):
-        def decorator(func):
-            return func
-        return decorator if args else decorator
-    
-    def prange(x):
-        return range(x)
+# Numba imports for JIT acceleration
+import numba
+from numba import jit, prange
+
+# Numba compilation settings for performance optimization
+NUMBA_OPTIONS = {"nopython": True, "fastmath": True, "cache": True, "parallel": True}
+
+logger.info("Numba %s successfully imported", getattr(numba, "__version__", "unknown"))
 
 # Core protocol import
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 
-# Configuration imports with fallback
-try:
-    from omegaconf import DictConfig
-    HYDRA_AVAILABLE = True
-except ImportError:
-    DictConfig = dict
-    HYDRA_AVAILABLE = False
+# Hydra imports
+import hydra
+from omegaconf import DictConfig
 
-# Logging imports
-import logging
-logger = logging.getLogger(__name__)
+logger.info("Hydra %s successfully imported", getattr(hydra, "__version__", "unknown"))
 
 
 @dataclass
 class TurbulentWindFieldConfig:
     """
     Configuration schema for TurbulentWindField with comprehensive parameter management.
-    
+
     This dataclass provides type-safe configuration for all turbulent wind field parameters
     including atmospheric conditions, turbulence characteristics, computational settings,
     and performance optimizations via Hydra configuration management.
-    
+
     Attributes:
         mean_velocity: Base wind vector as (u_x, u_y) in units per time step
         turbulence_intensity: Relative turbulence strength [0, 1] controlling eddy amplitudes
@@ -140,30 +124,30 @@ class TurbulentWindFieldConfig:
         boundary_conditions: Boundary condition type ('periodic', 'absorbing', 'reflecting')
         random_seed: Random seed for reproducible stochastic wind field generation
     """
-    
+
     # Base wind parameters
     mean_velocity: Tuple[float, float] = (3.0, 1.0)
     turbulence_intensity: float = 0.2
-    
+
     # Spatial and temporal correlation parameters
     correlation_length: float = 10.0
     correlation_time: float = 5.0
-    
+
     # Domain and computational settings
     domain_bounds: Tuple[float, float] = (100.0, 100.0)
     grid_resolution: float = 2.0
-    
+
     # Atmospheric boundary layer parameters
     anisotropy_ratio: float = 0.6
     atmospheric_stability: float = 0.0
     surface_roughness: float = 0.1
     thermal_effects: bool = False
-    
+
     # Performance optimization
     enable_numba: bool = True
     max_velocity_magnitude: float = 20.0
-    boundary_conditions: str = 'periodic'
-    
+    boundary_conditions: str = "periodic"
+
     # Reproducibility
     random_seed: Optional[int] = 42
 
@@ -171,18 +155,18 @@ class TurbulentWindFieldConfig:
 class TurbulentWindField:
     """
     Realistic turbulent wind field implementation providing gusty conditions and atmospheric boundary layer dynamics.
-    
+
     This implementation provides research-grade turbulent wind modeling using statistical approaches
     for atmospheric boundary layer physics, complex eddy interactions, and stochastic wind patterns
     matching real-world environmental conditions.
-    
+
     The model generates multi-scale turbulent velocity fields using:
     - Mean flow advection with configurable base wind patterns
     - Turbulent eddy structures with spatial and temporal correlation
     - Atmospheric boundary layer effects including stability and roughness
     - Stochastic velocity fluctuations using Ornstein-Uhlenbeck processes
     - Anisotropic turbulence tensors for realistic mixing characteristics
-    
+
     Key Implementation Features:
     - Performance-optimized computational kernels with optional Numba acceleration
     - Spatial interpolation for velocity queries with sub-grid accuracy
@@ -190,19 +174,19 @@ class TurbulentWindField:
     - Statistical modeling of turbulent transport phenomena using SciPy distributions
     - Memory-efficient data structures supporting large spatial domains
     - Advanced boundary condition handling for domain edge effects
-    
+
     Performance Characteristics:
     - velocity_at(): <0.5ms for single query, <5ms for field evaluation per protocol requirements
     - step(): <2ms per time step for minimal simulation overhead and real-time compatibility
     - Memory usage: <50MB for typical domains with spatial correlation enabled
     - Numba acceleration: 5-20x speedup for computational kernels when enabled
-    
+
     Examples:
         Basic turbulent wind field:
         >>> wind_field = TurbulentWindField()
         >>> positions = np.array([[25, 30], [35, 45]])
         >>> velocities = wind_field.velocity_at(positions)
-        
+
         High-turbulence atmospheric conditions:
         >>> config = TurbulentWindFieldConfig(
         ...     turbulence_intensity=0.4,
@@ -210,99 +194,101 @@ class TurbulentWindField:
         ...     thermal_effects=True
         ... )
         >>> wind_field = TurbulentWindField(config)
-        
+
         Integration with plume modeling:
         >>> turbulent_plume.set_wind_field(wind_field)
         >>> for t in range(100):
         ...     wind_field.step(dt=1.0)
         ...     turbulent_plume.step(dt=1.0)
     """
-    
+
     def __init__(
-        self,
-        config: Optional[TurbulentWindFieldConfig] = None,
-        **kwargs: Any
+        self, config: Optional[TurbulentWindFieldConfig] = None, **kwargs: Any
     ):
         """
         Initialize TurbulentWindField with configuration and atmospheric parameters.
-        
+
         Args:
             config: Configuration object with turbulent wind field parameters. If None,
                 uses default TurbulentWindFieldConfig with standard atmospheric values.
             **kwargs: Additional configuration parameters to override config values.
                 Useful for programmatic parameter exploration and testing.
-                
+
         Notes:
             Configuration parameter precedence: kwargs > config > defaults
             Random seed initialization ensures reproducible stochastic wind patterns.
             Numba compilation occurs on first computational kernel execution.
-            
+
         Examples:
             Default atmospheric configuration:
             >>> wind_field = TurbulentWindField()
-            
+
             Custom atmospheric conditions:
             >>> config = TurbulentWindFieldConfig(
-            ...     mean_velocity=(5.0, 2.0), 
+            ...     mean_velocity=(5.0, 2.0),
             ...     turbulence_intensity=0.3,
             ...     atmospheric_stability=-1.0
             ... )
             >>> wind_field = TurbulentWindField(config)
-            
+
             Parameter override for sensitivity analysis:
             >>> wind_field = TurbulentWindField(config, correlation_length=15.0)
         """
         # Initialize configuration with defaults and overrides
         self.config = config or TurbulentWindFieldConfig()
-        
+
         # Apply any parameter overrides from kwargs
         for key, value in kwargs.items():
             if hasattr(self.config, key):
                 setattr(self.config, key, value)
             else:
                 logger.warning(f"Unknown configuration parameter: {key}")
-        
+
         # Initialize random number generator for reproducible simulations
         if self.config.random_seed is not None:
             np.random.seed(self.config.random_seed)
-            
+
         # Initialize spatial grid for wind field computation
         self._initialize_spatial_grid()
-        
+
         # Initialize turbulent wind field state
         self._current_time = 0.0
-        self._velocity_field = np.zeros((self._grid_ny, self._grid_nx, 2), dtype=np.float64)
-        self._turbulent_component = np.zeros((self._grid_ny, self._grid_nx, 2), dtype=np.float64)
-        
+        self._velocity_field = np.zeros(
+            (self._grid_ny, self._grid_nx, 2), dtype=np.float64
+        )
+        self._turbulent_component = np.zeros(
+            (self._grid_ny, self._grid_nx, 2), dtype=np.float64
+        )
+
         # Initialize atmospheric boundary layer parameters
         self._initialize_atmospheric_parameters()
-        
+
         # Initialize spatial correlation matrices
         self._initialize_spatial_correlation()
-        
+
         # Initialize temporal correlation state
         self._previous_turbulence = np.zeros_like(self._turbulent_component)
-        
+
         # Performance monitoring
         self._step_times: List[float] = []
         self._velocity_times: List[float] = []
-        
+
         # Cache for optimized velocity computation
         self._velocity_cache: Dict[int, Tuple[float, np.ndarray]] = {}
         self._cache_valid = False
-        
+
         logger.info(
             f"Initialized TurbulentWindField with mean_velocity={self.config.mean_velocity}, "
             f"turbulence_intensity={self.config.turbulence_intensity:.3f}, "
             f"correlation_length={self.config.correlation_length:.1f}, "
             f"grid_resolution={self.config.grid_resolution:.1f}, "
-            f"Numba={'enabled' if self.config.enable_numba and NUMBA_AVAILABLE else 'disabled'}"
+            f"Numba={'enabled' if self.config.enable_numba else 'disabled'}"
         )
-    
+
     def _initialize_spatial_grid(self) -> None:
         """
         Initialize spatial grid for turbulent wind field computation.
-        
+
         Creates regular grid covering the simulation domain for spatial interpolation
         of velocity fields. Grid resolution balances accuracy with computational
         efficiency for wind field queries and correlation modeling.
@@ -310,35 +296,38 @@ class TurbulentWindField:
         width, height = self.config.domain_bounds
         self._grid_nx = int(width / self.config.grid_resolution) + 1
         self._grid_ny = int(height / self.config.grid_resolution) + 1
-        
+
         x = np.linspace(0, width, self._grid_nx)
         y = np.linspace(0, height, self._grid_ny)
         self._grid_x, self._grid_y = np.meshgrid(x, y)
-        
+
         # Flatten for efficient computation
-        self._grid_points = np.column_stack([
-            self._grid_x.ravel(), 
-            self._grid_y.ravel()
-        ])
-        
-        logger.debug(f"Initialized wind field grid: {self._grid_nx}x{self._grid_ny} points, "
-                    f"resolution={self.config.grid_resolution}")
-    
+        self._grid_points = np.column_stack(
+            [self._grid_x.ravel(), self._grid_y.ravel()]
+        )
+
+        logger.debug(
+            f"Initialized wind field grid: {self._grid_nx}x{self._grid_ny} points, "
+            f"resolution={self.config.grid_resolution}"
+        )
+
     def _initialize_atmospheric_parameters(self) -> None:
         """
         Initialize atmospheric boundary layer parameters for realistic wind modeling.
-        
+
         Computes derived parameters from atmospheric stability, surface roughness,
         and thermal effects to provide physically consistent turbulent structure.
         """
         # Atmospheric stability effects on turbulence structure
         stability = self.config.atmospheric_stability
         self._richardson_number = stability  # Simplified Richardson number
-        
+
         # Surface roughness effects on wind shear
         roughness = self.config.surface_roughness
-        self._friction_velocity = np.linalg.norm(self.config.mean_velocity) * roughness * 0.1
-        
+        self._friction_velocity = (
+            np.linalg.norm(self.config.mean_velocity) * roughness * 0.1
+        )
+
         # Mixing length scale based on atmospheric conditions
         if stability < -0.5:  # Unstable conditions (convective)
             self._mixing_length = self.config.correlation_length * 1.5
@@ -346,108 +335,122 @@ class TurbulentWindField:
             self._mixing_length = self.config.correlation_length * 0.7
         else:  # Neutral conditions
             self._mixing_length = self.config.correlation_length
-            
+
         # Anisotropy tensor for directional turbulence characteristics
         aniso = self.config.anisotropy_ratio
-        self._turbulence_tensor = np.array([
-            [1.0, 0.0],           # Along-wind turbulence (stronger)
-            [0.0, aniso]          # Cross-wind turbulence (weaker)
-        ])
-        
-        logger.debug(f"Atmospheric parameters: Richardson={self._richardson_number:.3f}, "
-                    f"friction_velocity={self._friction_velocity:.3f}, "
-                    f"mixing_length={self._mixing_length:.1f}")
-    
+        self._turbulence_tensor = np.array(
+            [
+                [1.0, 0.0],  # Along-wind turbulence (stronger)
+                [0.0, aniso],  # Cross-wind turbulence (weaker)
+            ]
+        )
+
+        logger.debug(
+            f"Atmospheric parameters: Richardson={self._richardson_number:.3f}, "
+            f"friction_velocity={self._friction_velocity:.3f}, "
+            f"mixing_length={self._mixing_length:.1f}"
+        )
+
     def _initialize_spatial_correlation(self) -> None:
         """
         Initialize spatial correlation matrices for realistic eddy structure.
-        
+
         Computes correlation matrices based on exponential decay functions
         with characteristic length scales matching atmospheric boundary layer theory.
         """
         # Compute distance matrices for spatial correlation
         n_points = len(self._grid_points)
-        
+
         if SCIPY_AVAILABLE and n_points < 10000:  # Memory constraint
             # Full distance matrix for small grids
             self._distance_matrix = cdist(self._grid_points, self._grid_points)
-            
+
             # Exponential correlation with characteristic length scale
             correlation_scale = self.config.correlation_length
-            self._spatial_correlation = np.exp(-self._distance_matrix / correlation_scale)
-            
+            self._spatial_correlation = np.exp(
+                -self._distance_matrix / correlation_scale
+            )
+
             # Apply atmospheric stability corrections
             stability_factor = 1.0 + 0.2 * self.config.atmospheric_stability
             self._spatial_correlation *= stability_factor
-            
-            logger.debug(f"Initialized full spatial correlation matrix: {n_points}x{n_points}")
+
+            logger.debug(
+                f"Initialized full spatial correlation matrix: {n_points}x{n_points}"
+            )
         else:
             # Sparse correlation for large grids or when SciPy unavailable
             self._distance_matrix = None
             self._spatial_correlation = None
-            logger.debug("Using local correlation approximation for large grid or missing SciPy")
-    
+            logger.debug(
+                "Using local correlation approximation for large grid or missing SciPy"
+            )
+
     def velocity_at(self, positions: np.ndarray) -> np.ndarray:
         """
         Compute wind velocity vectors at specified spatial locations using turbulent field interpolation.
-        
+
         This method implements high-performance spatial interpolation of turbulent wind velocity
         fields to provide realistic environmental dynamics for plume transport modeling. Uses
         optimized algorithms with optional Numba acceleration for real-time query performance.
-        
+
         Args:
             positions: Agent positions as array with shape (n_positions, 2) for multiple
                 positions or (2,) for single position. Coordinates in environment units.
-                
+
         Returns:
             np.ndarray: Velocity vectors with shape (n_positions, 2) or (2,) for single
                 position. Components represent [u_x, u_y] in environment units per time step.
-                
+
         Notes:
             Uses bilinear interpolation from grid-based velocity field with sub-grid accuracy.
             Accounts for mean flow, turbulent fluctuations, and atmospheric boundary layer
             effects for realistic wind patterns matching environmental conditions.
-            
+
             Performance optimizations include:
             - Grid-based spatial partitioning for efficient neighbor queries
             - Velocity caching for repeated query patterns
             - Numba-accelerated interpolation kernels when available
             - Boundary condition handling for positions outside domain
-            
+
         Performance:
             Executes in <0.5ms for single query, <5ms for field evaluation per protocol requirements.
-            
+
         Examples:
             Single position velocity query:
             >>> position = np.array([25.5, 35.2])
             >>> velocity = wind_field.velocity_at(position)
-            
+
             Multi-position batch query:
             >>> positions = np.array([[25, 30], [35, 45], [15, 20]])
             >>> velocities = wind_field.velocity_at(positions)
         """
         start_time = time.perf_counter()
-        
+
         # Handle input shape normalization
         positions = np.atleast_2d(positions)
         if positions.shape[1] != 2:
             if positions.shape[0] == 2 and positions.shape[1] != 2:
                 positions = positions.T
             else:
-                raise ValueError(f"Invalid position shape: {positions.shape}. Expected (n, 2) or (2,)")
-        
-        # Use optimized Numba kernel if available
-        if self.config.enable_numba and NUMBA_AVAILABLE:
+                raise ValueError(
+                    f"Invalid position shape: {positions.shape}. Expected (n, 2) or (2,)"
+                )
+
+        # Use optimized Numba kernel if enabled
+        if self.config.enable_numba:
             velocities = self._velocity_at_numba(positions)
         else:
             velocities = self._velocity_at_python(positions)
-        
+
         # Record performance metrics
         execution_time = time.perf_counter() - start_time
         self._velocity_times.append(execution_time)
-        
+
         # Maintain performance monitoring with warnings
-        if execution_time > 0.0005 and len(positions) == 1:  # 0.5ms threshold for single query
+        if (
+            execution_time > 0.0005 and len(positions) == 1
+        ):  # 0.5ms threshold for single query
             logger.warning(
                 f"Slow velocity query: {execution_time*1000:.2f}ms for single position"
             )
@@ -456,34 +459,38 @@ class TurbulentWindField:
                 f"Slow batch velocity query: {execution_time*1000:.2f}ms for "
                 f"{len(positions)} positions"
             )
-        
-        return velocities.item() if velocities.size == 2 and len(positions) == 1 else velocities
-    
+
+        return (
+            velocities.item()
+            if velocities.size == 2 and len(positions) == 1
+            else velocities
+        )
+
     def _velocity_at_python(self, positions: np.ndarray) -> np.ndarray:
         """
         Python implementation of turbulent wind velocity field interpolation.
-        
+
         Args:
             positions: Query positions with shape (n_positions, 2)
-            
+
         Returns:
             np.ndarray: Velocity vectors with shape (n_positions, 2)
         """
         n_positions = positions.shape[0]
         velocities = np.zeros((n_positions, 2), dtype=np.float64)
-        
+
         # Grid bounds for interpolation
         width, height = self.config.domain_bounds
         dx = self.config.grid_resolution
-        
+
         for i, pos in enumerate(positions):
             x, y = pos
-            
+
             # Handle boundary conditions
-            if self.config.boundary_conditions == 'periodic':
+            if self.config.boundary_conditions == "periodic":
                 x = x % width
                 y = y % height
-            elif self.config.boundary_conditions == 'absorbing':
+            elif self.config.boundary_conditions == "absorbing":
                 if x < 0 or x >= width or y < 0 or y >= height:
                     # Return zero velocity outside domain
                     velocities[i] = [0.0, 0.0]
@@ -491,114 +498,98 @@ class TurbulentWindField:
             else:  # 'reflecting'
                 x = np.clip(x, 0, width - 1e-6)
                 y = np.clip(y, 0, height - 1e-6)
-            
+
             # Grid indices for bilinear interpolation
             i_x = int(x / dx)
             i_y = int(y / dx)
-            
+
             # Fractional components
             fx = (x / dx) - i_x
             fy = (y / dx) - i_y
-            
+
             # Ensure indices are within bounds
             i_x = min(i_x, self._grid_nx - 2)
             i_y = min(i_y, self._grid_ny - 2)
-            
+
             # Bilinear interpolation
             v00 = self._velocity_field[i_y, i_x]
             v10 = self._velocity_field[i_y, i_x + 1]
             v01 = self._velocity_field[i_y + 1, i_x]
             v11 = self._velocity_field[i_y + 1, i_x + 1]
-            
+
             # Interpolate in x direction
             v0 = v00 * (1 - fx) + v10 * fx
             v1 = v01 * (1 - fx) + v11 * fx
-            
+
             # Interpolate in y direction
             velocities[i] = v0 * (1 - fy) + v1 * fy
-        
+
         return velocities
-    
-    if NUMBA_AVAILABLE:
-        @staticmethod
-        @jit(**NUMBA_OPTIONS)
-        def _velocity_interpolation_numba(
-            positions: np.ndarray,
-            velocity_field: np.ndarray,
-            grid_nx: int,
-            grid_ny: int,
-            grid_resolution: float,
-            domain_width: float,
-            domain_height: float,
-            boundary_periodic: bool
-        ) -> np.ndarray:
-            """
-            Numba-accelerated kernel for velocity field interpolation.
-            
-            Args:
-                positions: Query positions (n_positions, 2)
-                velocity_field: Grid velocity field (grid_ny, grid_nx, 2)
-                grid_nx: Number of grid points in x direction
-                grid_ny: Number of grid points in y direction  
-                grid_resolution: Grid spacing
-                domain_width: Domain width
-                domain_height: Domain height
-                boundary_periodic: Use periodic boundary conditions
-                
-            Returns:
-                np.ndarray: Interpolated velocity vectors (n_positions, 2)
-            """
-            n_positions = positions.shape[0]
-            velocities = np.zeros((n_positions, 2), dtype=np.float64)
-            
-            for i in prange(n_positions):
-                x, y = positions[i, 0], positions[i, 1]
-                
-                # Handle boundary conditions
-                if boundary_periodic:
-                    x = x % domain_width
-                    y = y % domain_height
-                else:
-                    if x < 0 or x >= domain_width or y < 0 or y >= domain_height:
-                        velocities[i, 0] = 0.0
-                        velocities[i, 1] = 0.0
-                        continue
-                    x = max(0, min(x, domain_width - 1e-6))
-                    y = max(0, min(y, domain_height - 1e-6))
-                
-                # Grid indices
-                i_x = int(x / grid_resolution)
-                i_y = int(y / grid_resolution)
-                
-                # Fractional components
-                fx = (x / grid_resolution) - i_x
-                fy = (y / grid_resolution) - i_y
-                
-                # Ensure indices are within bounds
-                i_x = min(i_x, grid_nx - 2)
-                i_y = min(i_y, grid_ny - 2)
-                
-                # Bilinear interpolation
-                for component in range(2):
-                    v00 = velocity_field[i_y, i_x, component]
-                    v10 = velocity_field[i_y, i_x + 1, component]
-                    v01 = velocity_field[i_y + 1, i_x, component]
-                    v11 = velocity_field[i_y + 1, i_x + 1, component]
-                    
-                    # Interpolate
-                    v0 = v00 * (1 - fx) + v10 * fx
-                    v1 = v01 * (1 - fx) + v11 * fx
-                    velocities[i, component] = v0 * (1 - fy) + v1 * fy
-            
-            return velocities
-    
+
+    @staticmethod
+    @jit(**NUMBA_OPTIONS)
+    def _velocity_interpolation_numba(
+        positions: np.ndarray,
+        velocity_field: np.ndarray,
+        grid_nx: int,
+        grid_ny: int,
+        grid_resolution: float,
+        domain_width: float,
+        domain_height: float,
+        boundary_periodic: bool,
+    ) -> np.ndarray:
+        """Numba-accelerated kernel for velocity field interpolation."""
+        n_positions = positions.shape[0]
+        velocities = np.zeros((n_positions, 2), dtype=np.float64)
+
+        for i in prange(n_positions):
+            x, y = positions[i, 0], positions[i, 1]
+
+            # Handle boundary conditions
+            if boundary_periodic:
+                x = x % domain_width
+                y = y % domain_height
+            else:
+                if x < 0 or x >= domain_width or y < 0 or y >= domain_height:
+                    velocities[i, 0] = 0.0
+                    velocities[i, 1] = 0.0
+                    continue
+                x = max(0, min(x, domain_width - 1e-6))
+                y = max(0, min(y, domain_height - 1e-6))
+
+            # Grid indices
+            i_x = int(x / grid_resolution)
+            i_y = int(y / grid_resolution)
+
+            # Fractional components
+            fx = (x / grid_resolution) - i_x
+            fy = (y / grid_resolution) - i_y
+
+            # Ensure indices are within bounds
+            i_x = min(i_x, grid_nx - 2)
+            i_y = min(i_y, grid_ny - 2)
+
+            # Bilinear interpolation
+            for component in range(2):
+                v00 = velocity_field[i_y, i_x, component]
+                v10 = velocity_field[i_y, i_x + 1, component]
+                v01 = velocity_field[i_y + 1, i_x, component]
+                v11 = velocity_field[i_y + 1, i_x + 1, component]
+
+                # Interpolate
+                v0 = v00 * (1 - fx) + v10 * fx
+                v1 = v01 * (1 - fx) + v11 * fx
+                velocities[i, component] = v0 * (1 - fy) + v1 * fy
+
+        return velocities
+
     def _velocity_at_numba(self, positions: np.ndarray) -> np.ndarray:
         """
         Numba-accelerated velocity field computation wrapper.
-        
+
         Args:
             positions: Query positions with shape (n_positions, 2)
-            
+
         Returns:
             np.ndarray: Velocity vectors with shape (n_positions, 2)
         """
@@ -610,25 +601,25 @@ class TurbulentWindField:
             self.config.grid_resolution,
             self.config.domain_bounds[0],
             self.config.domain_bounds[1],
-            self.config.boundary_conditions == 'periodic'
+            self.config.boundary_conditions == "periodic",
         )
-    
+
     def step(self, dt: float = 1.0) -> None:
         """
         Advance turbulent wind field state by specified time delta with realistic atmospheric physics.
-        
+
         This method implements the core temporal evolution of the turbulent wind field including:
         - Stochastic generation of turbulent velocity fluctuations using statistical models
         - Spatial correlation enforcement for realistic eddy structure and mixing patterns
         - Temporal correlation via Ornstein-Uhlenbeck processes for smooth evolution
         - Atmospheric boundary layer effects including stability and surface roughness
         - Mean flow evolution with optional thermal and pressure gradient effects
-        
+
         Args:
             dt: Time step size in seconds controlling temporal resolution of
                 atmospheric dynamics. Smaller values provide higher accuracy
                 at increased computational cost.
-                
+
         Notes:
             Physics integration uses operator splitting for numerical stability:
             1. Generate new turbulent fluctuations with proper statistical properties
@@ -637,103 +628,105 @@ class TurbulentWindField:
             4. Apply atmospheric boundary layer corrections
             5. Update mean flow components (if enabled)
             6. Enforce velocity magnitude constraints for numerical stability
-            
+
             Performance optimizations include vectorized operations, Numba acceleration,
             and efficient correlation matrix operations for real-time simulation compatibility.
-            
+
         Performance:
             Executes in <2ms per step per protocol requirements supporting real-time simulation.
-            
+
         Examples:
             Standard time step advancement:
             >>> wind_field.step(dt=1.0)
-            
+
             High-frequency atmospheric evolution:
             >>> for _ in range(10):
             ...     wind_field.step(dt=0.1)  # 10x higher temporal resolution
         """
         start_time = time.perf_counter()
-        
+
         # 1. Generate new turbulent fluctuations with proper statistical properties
         self._generate_turbulent_fluctuations(dt)
-        
+
         # 2. Apply spatial correlation for realistic eddy structure
         self._apply_spatial_correlation()
-        
+
         # 3. Integrate temporal correlation for smooth velocity evolution
         self._integrate_temporal_correlation(dt)
-        
+
         # 4. Update mean velocity field (base flow + boundary layer effects)
         self._update_mean_velocity_field(dt)
-        
+
         # 5. Apply atmospheric boundary layer corrections
         self._apply_atmospheric_corrections(dt)
-        
+
         # 6. Combine mean flow and turbulent components
         self._compute_total_velocity_field()
-        
+
         # Update simulation time
         self._current_time += dt
-        
+
         # Record performance metrics
         execution_time = time.perf_counter() - start_time
         self._step_times.append(execution_time)
-        
+
         # Invalidate velocity cache
         self._cache_valid = False
-        
+
         # Performance monitoring with warnings
         if execution_time > 0.002:  # 2ms threshold per protocol
             logger.warning(
                 f"Slow wind field step: {execution_time*1000:.2f}ms with "
                 f"grid size {self._grid_nx}x{self._grid_ny}"
             )
-        
+
         logger.debug(
             f"Wind field step completed: t={self._current_time:.1f}, "
             f"grid_size={self._grid_nx}x{self._grid_ny}, dt={dt:.3f}, "
             f"execution_time={execution_time*1000:.2f}ms"
         )
-    
+
     def _generate_turbulent_fluctuations(self, dt: float) -> None:
         """
         Generate new turbulent velocity fluctuations with proper statistical properties.
-        
+
         Uses statistical models based on atmospheric boundary layer theory to generate
         realistic turbulent fluctuations with correct energy spectra and correlation structure.
-        
+
         Args:
             dt: Time step size for scaling stochastic increments
         """
         # Turbulent velocity standard deviation based on turbulence intensity
         mean_speed = np.linalg.norm(self.config.mean_velocity)
         velocity_std = self.config.turbulence_intensity * mean_speed
-        
+
         # Account for atmospheric stability effects
         stability_factor = 1.0 + 0.3 * abs(self.config.atmospheric_stability)
         if self.config.atmospheric_stability < 0:  # Unstable (convective)
             velocity_std *= stability_factor
         else:  # Stable (suppressed turbulence)
             velocity_std /= stability_factor
-        
+
         # Generate random fluctuations with proper scaling
         random_shape = (self._grid_ny, self._grid_nx, 2)
-        random_fluctuations = np.random.normal(0, velocity_std * np.sqrt(dt), random_shape)
-        
+        random_fluctuations = np.random.normal(
+            0, velocity_std * np.sqrt(dt), random_shape
+        )
+
         # Apply anisotropy tensor for directional characteristics
         for i in range(self._grid_ny):
             for j in range(self._grid_nx):
                 # Transform fluctuations by anisotropy tensor
                 fluctuation = random_fluctuations[i, j]
                 random_fluctuations[i, j] = self._turbulence_tensor @ fluctuation
-        
+
         # Store for spatial correlation processing
         self._raw_fluctuations = random_fluctuations
-    
+
     def _apply_spatial_correlation(self) -> None:
         """
         Apply spatial correlation to turbulent fluctuations for realistic eddy structure.
-        
+
         Uses correlation matrices or local approximations to enforce spatial structure
         matching atmospheric boundary layer characteristics.
         """
@@ -742,13 +735,13 @@ class TurbulentWindField:
             for component in range(2):
                 # Flatten spatial field
                 field_flat = self._raw_fluctuations[:, :, component].ravel()
-                
+
                 # Apply spatial correlation
                 correlated_field = self._spatial_correlation @ field_flat
-                
+
                 # Normalize to preserve variance
                 correlated_field /= np.sqrt(len(field_flat))
-                
+
                 # Reshape back to grid
                 self._raw_fluctuations[:, :, component] = correlated_field.reshape(
                     self._grid_ny, self._grid_nx
@@ -756,37 +749,43 @@ class TurbulentWindField:
         else:
             # Local correlation approximation for large grids
             self._apply_local_spatial_correlation()
-    
+
     def _apply_local_spatial_correlation(self) -> None:
         """
         Apply local spatial correlation using convolution-based approach.
-        
+
         Uses local correlation kernels to approximate spatial structure when
         full correlation matrices are computationally prohibitive.
         """
         # Create correlation kernel based on correlation length
-        kernel_size = max(3, int(2 * self.config.correlation_length / self.config.grid_resolution))
+        kernel_size = max(
+            3, int(2 * self.config.correlation_length / self.config.grid_resolution)
+        )
         if kernel_size % 2 == 0:
             kernel_size += 1  # Ensure odd size
-        
+
         # Gaussian correlation kernel
         center = kernel_size // 2
         y_kernel, x_kernel = np.meshgrid(
-            np.arange(kernel_size) - center,
-            np.arange(kernel_size) - center
+            np.arange(kernel_size) - center, np.arange(kernel_size) - center
         )
         distances = np.sqrt(x_kernel**2 + y_kernel**2) * self.config.grid_resolution
         correlation_kernel = np.exp(-distances / self.config.correlation_length)
         correlation_kernel /= np.sum(correlation_kernel)  # Normalize
-        
+
         # Apply convolution for spatial correlation
         from scipy import ndimage
+
         if SCIPY_AVAILABLE:
             for component in range(2):
                 self._raw_fluctuations[:, :, component] = ndimage.convolve(
                     self._raw_fluctuations[:, :, component],
                     correlation_kernel,
-                    mode='wrap' if self.config.boundary_conditions == 'periodic' else 'nearest'
+                    mode=(
+                        "wrap"
+                        if self.config.boundary_conditions == "periodic"
+                        else "nearest"
+                    ),
                 )
         else:
             # Simple local averaging fallback
@@ -796,14 +795,16 @@ class TurbulentWindField:
                     for j in range(1, self._grid_nx - 1):
                         # 3x3 local average
                         smoothed[i, j] = np.mean(
-                            self._raw_fluctuations[i-1:i+2, j-1:j+2, component]
+                            self._raw_fluctuations[
+                                i - 1 : i + 2, j - 1 : j + 2, component
+                            ]
                         )
                 self._raw_fluctuations[:, :, component] = smoothed
-    
+
     def _integrate_temporal_correlation(self, dt: float) -> None:
         """
         Integrate temporal correlation using Ornstein-Uhlenbeck process for smooth evolution.
-        
+
         Args:
             dt: Time step size for temporal integration
         """
@@ -811,86 +812,89 @@ class TurbulentWindField:
         tau = self.config.correlation_time
         alpha = dt / tau if tau > 0 else 1.0
         alpha = min(alpha, 1.0)  # Numerical stability
-        
+
         # Ornstein-Uhlenbeck integration: v(t+dt) = (1-α)v(t) + α*ξ(t)
         self._turbulent_component = (
-            (1 - alpha) * self._previous_turbulence + 
-            alpha * self._raw_fluctuations
-        )
-        
+            1 - alpha
+        ) * self._previous_turbulence + alpha * self._raw_fluctuations
+
         # Store for next time step
         self._previous_turbulence = np.copy(self._turbulent_component)
-    
+
     def _update_mean_velocity_field(self, dt: float) -> None:
         """
         Update mean velocity field with atmospheric effects.
-        
+
         Args:
             dt: Time step size for mean flow evolution
         """
         # Base mean velocity field (uniform for now)
         mean_u, mean_v = self.config.mean_velocity
-        
+
         # Apply thermal effects if enabled
         if self.config.thermal_effects:
             # Simple thermal stratification model
             height_factor = np.linspace(0, 1, self._grid_ny)
             thermal_correction = 0.1 * self.config.atmospheric_stability * height_factor
             mean_v += thermal_correction.reshape(-1, 1)
-        
+
         # Create uniform mean velocity field
         self._mean_velocity_field = np.zeros((self._grid_ny, self._grid_nx, 2))
         self._mean_velocity_field[:, :, 0] = mean_u
         self._mean_velocity_field[:, :, 1] = mean_v
-    
+
     def _apply_atmospheric_corrections(self, dt: float) -> None:
         """
         Apply atmospheric boundary layer corrections to velocity field.
-        
+
         Args:
             dt: Time step size for atmospheric corrections
         """
         # Surface roughness effects (simplified wind shear)
         if self.config.surface_roughness > 0:
-            height_factor = np.linspace(0.1, 1.0, self._grid_ny)  # Approximate height effect
+            height_factor = np.linspace(
+                0.1, 1.0, self._grid_ny
+            )  # Approximate height effect
             shear_factor = np.log(height_factor / self.config.surface_roughness + 1)
             shear_factor = shear_factor.reshape(-1, 1, 1)
-            
+
             # Apply logarithmic wind profile correction
             self._turbulent_component *= shear_factor
-    
+
     def _compute_total_velocity_field(self) -> None:
         """
         Combine mean flow and turbulent components to create total velocity field.
-        
+
         Enforces physical constraints including maximum velocity limits and
         ensures numerical stability for downstream computations.
         """
         # Combine mean and turbulent components
         self._velocity_field = self._mean_velocity_field + self._turbulent_component
-        
+
         # Enforce maximum velocity constraint for numerical stability
         velocity_magnitudes = np.linalg.norm(self._velocity_field, axis=2)
         exceed_mask = velocity_magnitudes > self.config.max_velocity_magnitude
-        
+
         if np.any(exceed_mask):
             # Scale down velocities that exceed maximum
             scale_factors = self.config.max_velocity_magnitude / velocity_magnitudes
             scale_factors = np.where(exceed_mask, scale_factors, 1.0)
-            
+
             self._velocity_field[:, :, 0] *= scale_factors
             self._velocity_field[:, :, 1] *= scale_factors
-            
-            logger.debug(f"Velocity limiting applied to {np.sum(exceed_mask)} grid points")
-    
+
+            logger.debug(
+                f"Velocity limiting applied to {np.sum(exceed_mask)} grid points"
+            )
+
     def reset(self, **kwargs: Any) -> None:
         """
         Reset turbulent wind field to initial conditions with optional parameter updates.
-        
+
         Reinitializes the turbulent wind field simulation to clean initial state while
         preserving model configuration. Supports parameter overrides for episodic
         experiments with different atmospheric conditions.
-        
+
         Args:
             **kwargs: Optional parameters to override initial settings. Common options:
                 - mean_velocity: Base wind vector (u_x, u_y)
@@ -898,30 +902,30 @@ class TurbulentWindField:
                 - correlation_length: Spatial correlation scale for eddy structure
                 - atmospheric_stability: Stability parameter affecting boundary layer
                 - random_seed: New random seed for stochastic processes
-                
+
         Notes:
             Parameter overrides apply to current episode only unless explicitly
             configured for persistence. Wind field state is completely reinitialized
             including spatial grids, correlation matrices, and temporal state.
-            
+
             Clears all existing velocity fields and resets internal simulation state
             including time counters, performance metrics, and correlation caches.
-            
+
         Performance:
             Completes in <5ms per protocol requirements to avoid blocking episode initialization.
-            
+
         Examples:
             Reset to default initial state:
             >>> wind_field.reset()
-            
+
             Reset with stronger atmospheric turbulence:
             >>> wind_field.reset(turbulence_intensity=0.4, atmospheric_stability=-1.0)
-            
+
             Reset with different correlation structure:
             >>> wind_field.reset(correlation_length=15.0, anisotropy_ratio=0.8)
         """
         logger.info("Resetting TurbulentWindField to initial conditions")
-        
+
         # Apply parameter overrides to configuration
         for key, value in kwargs.items():
             if hasattr(self.config, key):
@@ -929,124 +933,137 @@ class TurbulentWindField:
                 logger.debug(f"Override parameter: {key} = {value}")
             else:
                 logger.warning(f"Unknown reset parameter: {key}")
-        
+
         # Reset random seed if specified
-        if 'random_seed' in kwargs and kwargs['random_seed'] is not None:
-            np.random.seed(kwargs['random_seed'])
+        if "random_seed" in kwargs and kwargs["random_seed"] is not None:
+            np.random.seed(kwargs["random_seed"])
         elif self.config.random_seed is not None:
             np.random.seed(self.config.random_seed)
-        
+
         # Reset simulation time
         self._current_time = 0.0
-        
+
         # Reinitialize spatial grid if domain bounds changed
-        if 'domain_bounds' in kwargs or 'grid_resolution' in kwargs:
+        if "domain_bounds" in kwargs or "grid_resolution" in kwargs:
             self._initialize_spatial_grid()
-        
+
         # Reinitialize atmospheric parameters if relevant parameters changed
-        if any(key in kwargs for key in ['atmospheric_stability', 'surface_roughness', 
-                                        'anisotropy_ratio', 'thermal_effects']):
+        if any(
+            key in kwargs
+            for key in [
+                "atmospheric_stability",
+                "surface_roughness",
+                "anisotropy_ratio",
+                "thermal_effects",
+            ]
+        ):
             self._initialize_atmospheric_parameters()
-        
+
         # Reinitialize spatial correlation if correlation parameters changed
-        if any(key in kwargs for key in ['correlation_length', 'atmospheric_stability']):
+        if any(
+            key in kwargs for key in ["correlation_length", "atmospheric_stability"]
+        ):
             self._initialize_spatial_correlation()
-        
+
         # Reset velocity field state
-        self._velocity_field = np.zeros((self._grid_ny, self._grid_nx, 2), dtype=np.float64)
-        self._turbulent_component = np.zeros((self._grid_ny, self._grid_nx, 2), dtype=np.float64)
+        self._velocity_field = np.zeros(
+            (self._grid_ny, self._grid_nx, 2), dtype=np.float64
+        )
+        self._turbulent_component = np.zeros(
+            (self._grid_ny, self._grid_nx, 2), dtype=np.float64
+        )
         self._previous_turbulence = np.zeros_like(self._turbulent_component)
-        
+
         # Clear performance monitoring data
         self._step_times.clear()
         self._velocity_times.clear()
-        
+
         # Invalidate caches
         self._velocity_cache.clear()
         self._cache_valid = False
-        
+
         logger.info(
             f"Reset complete: mean_velocity={self.config.mean_velocity}, "
             f"turbulence_intensity={self.config.turbulence_intensity}, "
             f"correlation_length={self.config.correlation_length}, "
             f"atmospheric_stability={self.config.atmospheric_stability}"
         )
-    
+
     # Additional utility methods for analysis and debugging
-    
+
     def get_performance_metrics(self) -> Dict[str, Any]:
         """
         Get performance monitoring metrics for analysis and optimization.
-        
+
         Returns:
             Dict with timing statistics, memory usage, and computational efficiency metrics.
         """
         if not self._step_times or not self._velocity_times:
             return {
-                'step_times': {'count': 0, 'mean': 0.0, 'max': 0.0},
-                'velocity_times': {'count': 0, 'mean': 0.0, 'max': 0.0},
-                'grid_size': f"{self._grid_nx}x{self._grid_ny}",
-                'simulation_time': self._current_time
+                "step_times": {"count": 0, "mean": 0.0, "max": 0.0},
+                "velocity_times": {"count": 0, "mean": 0.0, "max": 0.0},
+                "grid_size": f"{self._grid_nx}x{self._grid_ny}",
+                "simulation_time": self._current_time,
             }
-        
+
         return {
-            'step_times': {
-                'count': len(self._step_times),
-                'mean': np.mean(self._step_times) * 1000,  # Convert to ms
-                'max': np.max(self._step_times) * 1000,
-                'std': np.std(self._step_times) * 1000
+            "step_times": {
+                "count": len(self._step_times),
+                "mean": np.mean(self._step_times) * 1000,  # Convert to ms
+                "max": np.max(self._step_times) * 1000,
+                "std": np.std(self._step_times) * 1000,
             },
-            'velocity_times': {
-                'count': len(self._velocity_times),
-                'mean': np.mean(self._velocity_times) * 1000,
-                'max': np.max(self._velocity_times) * 1000,
-                'std': np.std(self._velocity_times) * 1000
+            "velocity_times": {
+                "count": len(self._velocity_times),
+                "mean": np.mean(self._velocity_times) * 1000,
+                "max": np.max(self._velocity_times) * 1000,
+                "std": np.std(self._velocity_times) * 1000,
             },
-            'grid_size': f"{self._grid_nx}x{self._grid_ny}",
-            'simulation_time': self._current_time,
-            'numba_enabled': self.config.enable_numba and NUMBA_AVAILABLE,
-            'scipy_available': SCIPY_AVAILABLE
+            "grid_size": f"{self._grid_nx}x{self._grid_ny}",
+            "simulation_time": self._current_time,
+            "numba_enabled": self.config.enable_numba,
+            "scipy_available": SCIPY_AVAILABLE,
         }
-    
+
     def get_wind_statistics(self) -> Dict[str, Any]:
         """
         Get statistical information about current wind field state.
-        
+
         Returns:
             Dict with velocity statistics, turbulence characteristics, and field properties.
         """
         if self._velocity_field.size == 0:
             return {
-                'mean_velocity': (0.0, 0.0),
-                'velocity_magnitude': {'mean': 0.0, 'max': 0.0, 'std': 0.0},
-                'turbulence_intensity': 0.0,
-                'grid_points': 0
+                "mean_velocity": (0.0, 0.0),
+                "velocity_magnitude": {"mean": 0.0, "max": 0.0, "std": 0.0},
+                "turbulence_intensity": 0.0,
+                "grid_points": 0,
             }
-        
+
         # Velocity statistics
         mean_u = np.mean(self._velocity_field[:, :, 0])
         mean_v = np.mean(self._velocity_field[:, :, 1])
-        
+
         velocity_magnitudes = np.linalg.norm(self._velocity_field, axis=2)
-        
+
         # Turbulence intensity calculation
         mean_speed = np.mean(velocity_magnitudes)
         turbulent_fluctuations = velocity_magnitudes - mean_speed
         turbulence_intensity = np.std(turbulent_fluctuations) / max(mean_speed, 1e-6)
-        
+
         return {
-            'mean_velocity': (mean_u, mean_v),
-            'velocity_magnitude': {
-                'mean': np.mean(velocity_magnitudes),
-                'max': np.max(velocity_magnitudes),
-                'std': np.std(velocity_magnitudes)
+            "mean_velocity": (mean_u, mean_v),
+            "velocity_magnitude": {
+                "mean": np.mean(velocity_magnitudes),
+                "max": np.max(velocity_magnitudes),
+                "std": np.std(velocity_magnitudes),
             },
-            'turbulence_intensity': turbulence_intensity,
-            'grid_points': self._grid_nx * self._grid_ny,
-            'atmospheric_stability': self.config.atmospheric_stability,
-            'correlation_length': self.config.correlation_length
+            "turbulence_intensity": turbulence_intensity,
+            "grid_points": self._grid_nx * self._grid_ny,
+            "atmospheric_stability": self.config.atmospheric_stability,
+            "correlation_length": self.config.correlation_length,
         }
-    
+
     def __repr__(self) -> str:
         """String representation for debugging and logging."""
         return (
@@ -1056,4 +1073,3 @@ class TurbulentWindField:
             f"mean_velocity={self.config.mean_velocity}, "
             f"turbulence_intensity={self.config.turbulence_intensity})"
         )
-

--- a/tests/models/test_turbulent_wind_dependencies.py
+++ b/tests/models/test_turbulent_wind_dependencies.py
@@ -1,0 +1,41 @@
+import importlib
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _simulate_missing_modules(monkeypatch, *module_names):
+    """Remove modules and make future imports fail for specified names."""
+    # Ensure source path is available for import
+    src_path = Path(__file__).resolve().parents[2] / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    # Remove modules from cache
+    for name in list(sys.modules):
+        if any(name == m or name.startswith(m + ".") for m in module_names):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    # Make future imports raise ImportError
+    original_import = builtins.__import__
+
+    def mocked_import(name, *args, **kwargs):
+        if any(name == m or name.startswith(m + ".") for m in module_names):
+            raise ImportError(f"No module named {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
+
+
+def test_missing_numba_raises_import_error(monkeypatch):
+    _simulate_missing_modules(monkeypatch, "numba")
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.models.wind.turbulent_wind")
+
+
+def test_missing_hydra_raises_import_error(monkeypatch):
+    _simulate_missing_modules(monkeypatch, "hydra", "omegaconf")
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.models.wind.turbulent_wind")


### PR DESCRIPTION
## Summary
- require Numba and Hydra imports in turbulent wind model
- log successful Numba and Hydra imports for visibility
- add tests ensuring ImportError is raised when Numba or Hydra are missing

## Testing
- `pytest tests/models/test_turbulent_wind_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e29fd1d483208e0bb0a6f4c42ba6