### PR TITLE
feat: enforce mandatory numba and hydra imports

### DIFF
--- a/src/plume_nav_sim/models/wind/turbulent_wind.py
+++ b/src/plume_nav_sim/models/wind/turbulent_wind.py
@@ -87,7 +87,9 @@ from numba import jit, prange
 # Numba compilation settings for performance optimization
 NUMBA_OPTIONS = {"nopython": True, "fastmath": True, "cache": True, "parallel": True}
 
-logger.info("Numba %s successfully imported", getattr(numba, "__version__", "unknown"))
+logger.info(
+    "Numba version %s successfully imported", getattr(numba, "__version__", "unknown")
+)
 
 # Core protocol import
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
@@ -96,7 +98,9 @@ from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 import hydra
 from omegaconf import DictConfig
 
-logger.info("Hydra %s successfully imported", getattr(hydra, "__version__", "unknown"))
+logger.info(
+    "Hydra version %s successfully imported", getattr(hydra, "__version__", "unknown")
+)
 
 
 @dataclass

--- a/tests/models/test_turbulent_wind_import_errors.py
+++ b/tests/models/test_turbulent_wind_import_errors.py
@@ -1,0 +1,43 @@
+import importlib
+import builtins
+import sys
+
+import pytest
+
+
+def test_missing_numba_raises_import_error(monkeypatch):
+    """Importing turbulent_wind without numba should raise ImportError."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("numba"):
+            raise ImportError("No module named 'numba'")
+        return real_import(name, *args, **kwargs)
+
+    for mod in list(sys.modules):
+        if mod.startswith("numba"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.models.wind.turbulent_wind", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.models.wind.turbulent_wind")
+
+
+def test_missing_hydra_raises_import_error(monkeypatch):
+    """Importing turbulent_wind without hydra should raise ImportError."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("hydra"):
+            raise ImportError("No module named 'hydra'")
+        return real_import(name, *args, **kwargs)
+
+    for mod in list(sys.modules):
+        if mod.startswith("hydra"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.models.wind.turbulent_wind", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.models.wind.turbulent_wind")


### PR DESCRIPTION
## Summary
- improve logging for Numba and Hydra imports
- add tests verifying turbulent_wind fails fast when Numba or Hydra missing

## Testing
- `pytest tests/models/test_turbulent_wind_import_errors.py -q`
- `pytest -q` *(fails: No module named 'plume_nav_sim.envs.video_plume')*

------
https://chatgpt.com/codex/tasks/task_e_68b8ea124ef48320bb7662e305eb2435