### PR TITLE
feat: raise on invalid sensor values

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -1457,15 +1457,19 @@ class SingleAgentController(BaseController):
             
             # Validate odor value
             if np.isnan(odor_value) or np.isinf(odor_value):
+                msg = (
+                    f"Invalid odor value {odor_value} from "
+                    f"{type(self._primary_sensor).__name__} at "
+                    f"{self._position[0].tolist()}"
+                )
                 if self._logger:
-                    self._logger.warning(
-                        "Invalid odor value detected from sensor",
+                    self._logger.error(
+                        msg,
                         odor_value=odor_value,
                         position=self._position[0].tolist(),
                         sensor_type=type(self._primary_sensor).__name__,
-                        using_fallback=True
                     )
-                odor_value = 0.0
+                raise ValueError(msg)
             
             # Track sampling performance
             if self._enable_logging:
@@ -1493,8 +1497,7 @@ class SingleAgentController(BaseController):
                     sensor_type=type(self._primary_sensor).__name__,
                     env_array_shape=getattr(env_array, 'shape', 'unknown')
                 )
-            # Return safe default value
-            return 0.0
+            raise RuntimeError(f"Sensor-based odor sampling failed: {e}") from e
     
     def sample_multiple_sensors(
         self,

--- a/tests/test_sensor_errors.py
+++ b/tests/test_sensor_errors.py
@@ -1,0 +1,72 @@
+import importlib.util
+import logging
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+def load_single_agent_controller():
+    """Load SingleAgentController with minimal dependency stubs."""
+    # Stub required modules to avoid heavy optional dependencies
+    stubs = {
+        'plume_nav_sim.protocols.navigator': types.SimpleNamespace(NavigatorProtocol=object),
+        'plume_nav_sim.core.protocols': types.SimpleNamespace(
+            BoundaryPolicyProtocol=object,
+            SourceProtocol=object,
+        ),
+        'plume_nav_sim.protocols.sensor': types.SimpleNamespace(SensorProtocol=object),
+        'plume_nav_sim.core.boundaries': types.SimpleNamespace(
+            create_boundary_policy=lambda *a, **k: object()
+        ),
+        'plume_nav_sim.envs.spaces': types.SimpleNamespace(SpacesFactory=object),
+        'plume_nav_sim.utils.frame_cache': types.SimpleNamespace(
+            FrameCache=object,
+            CacheMode=object,
+        ),
+        'plume_nav_sim.utils.logging_setup': types.SimpleNamespace(
+            get_enhanced_logger=logging.getLogger
+        ),
+        'plume_nav_sim.utils.seed_manager': types.ModuleType('seed_manager'),
+        'plume_nav_sim.utils.visualization': types.ModuleType('visualization'),
+        'plume_nav_sim.utils.io': types.ModuleType('io'),
+        'plume_nav_sim.utils.navigator_utils': types.ModuleType('navigator_utils'),
+        'plume_nav_sim.envs.video_plume': types.SimpleNamespace(VideoPlume=object),
+        'plume_nav_sim.config.schemas': types.SimpleNamespace(
+            NavigatorConfig=object,
+            SingleAgentConfig=object,
+            MultiAgentConfig=object,
+        ),
+    }
+    for name, module in stubs.items():
+        sys.modules.setdefault(name, module)
+
+    # Ensure package parents exist for relative imports
+    for pkg in [
+        'plume_nav_sim',
+        'plume_nav_sim.core',
+        'plume_nav_sim.envs',
+        'plume_nav_sim.utils',
+        'plume_nav_sim.protocols',
+        'plume_nav_sim.config',
+    ]:
+        sys.modules.setdefault(pkg, types.ModuleType(pkg))
+
+    spec = importlib.util.spec_from_file_location(
+        'plume_nav_sim.core.controllers',
+        'src/plume_nav_sim/core/controllers.py',
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['plume_nav_sim.core.controllers'] = module
+    spec.loader.exec_module(module)
+    return module.SingleAgentController
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_read_single_antenna_odor_invalid_sensor_values_raise(bad_value):
+    SingleAgentController = load_single_agent_controller()
+    controller = SingleAgentController(position=(0, 0))
+    environment = np.array([[bad_value]], dtype=float)
+    with pytest.raises(RuntimeError):
+        controller.read_single_antenna_odor(environment)


### PR DESCRIPTION
## Summary
- raise ValueError when single-antenna sensor returns NaN/inf and log details
- propagate sensor sampling errors as RuntimeError
- add test ensuring invalid sensor readings raise

## Testing
- `pytest tests/test_sensor_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8eebd360c8320a8ac17296607a962