### PR TITLE
feat: require SciPy for turbulent wind spatial correlation

### DIFF
--- a/tests/models/test_turbulent_wind_import.py
+++ b/tests/models/test_turbulent_wind_import.py
@@ -1,0 +1,41 @@
+import builtins
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def test_turbulent_wind_requires_scipy(monkeypatch):
+    """Turbulent wind module should raise ImportError when SciPy is missing."""
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "plume_nav_sim"
+        / "models"
+        / "wind"
+        / "turbulent_wind.py"
+    )
+
+    # Simulate missing SciPy
+    for mod in list(sys.modules):
+        if mod.startswith("scipy"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("scipy"):
+            raise ImportError("No module named 'scipy'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    spec = importlib.util.spec_from_file_location(
+        "turbulent_wind_missing_scipy", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ImportError) as excinfo:
+        spec.loader.exec_module(module)
+    assert "scipy" in str(excinfo.value).lower()


### PR DESCRIPTION
## Summary
- remove SCIPY_AVAILABLE flag and require SciPy
- compute spatial correlation using SciPy only
- test that turbulent wind import fails without SciPy

## Testing
- `pytest tests/models/test_turbulent_wind_import.py -q`
- `pytest tests/models/test_wind_fields.py::TestTurbulentWindFieldProtocol::test_protocol_interface_compliance -q` *(fails: ModuleNotFoundError: No module named 'plume_nav_sim.envs.video_plume')*


------
https://chatgpt.com/codex/tasks/task_e_68b8eebecce883209b483643ca38074f