### PR TITLE
refactor: require Hydra for analysis

### DIFF
--- a/src/plume_nav_sim/analysis/__init__.py
+++ b/src/plume_nav_sim/analysis/__init__.py
@@ -100,13 +100,8 @@ from ..recording import RecorderFactory
 logger = logging.getLogger(__name__)
 
 # Hydra configuration support (fail fast if unavailable)
-try:
-    from hydra import instantiate
-    from omegaconf import DictConfig
-    HYDRA_AVAILABLE = True
-except ImportError as e:  # pragma: no cover - executed when Hydra is missing
-    logger.error("Hydra is required for configuration-driven analysis: %s", e)
-    raise
+from hydra import instantiate
+from omegaconf import DictConfig
 
 # Module version for API compatibility tracking
 __version__ = "1.0.0"
@@ -186,15 +181,6 @@ def create_from_config(config: Union[Dict[str, Any], DictConfig]) -> StatsAggreg
         >>> aggregator = create_from_config(config)
     """
     try:
-        # Validate Hydra availability for advanced features
-        if isinstance(config, DictConfig) and not HYDRA_AVAILABLE:
-            warnings.warn(
-                "Hydra not available. Some configuration features may be limited. "
-                "Install hydra-core for full functionality.",
-                UserWarning,
-                stacklevel=2
-            )
-        
         # Handle different configuration types
         if isinstance(config, DictConfig):
             # Check for Hydra instantiation target
@@ -602,12 +588,8 @@ def check_analysis_dependencies() -> Dict[str, Any]:
                     "pip install pyarrow"
                 )
     
-    # Check Hydra availability status
-    dependency_status['hydra_available'] = HYDRA_AVAILABLE
-    if not HYDRA_AVAILABLE:
-        dependency_status['warnings'].append(
-            "Hydra configuration features disabled. Some advanced functionality unavailable."
-        )
+    # Hydra is a required dependency
+    dependency_status['hydra_available'] = True
     
     # Performance recommendations based on available dependencies
     if dependency_status['optional_dependencies'].get('psutil', False):
@@ -969,10 +951,6 @@ try:
     
     # Log successful initialization
     logger.debug(f"Analysis module initialized successfully (version {__version__})")
-    
-    # Log optional dependency status
-    if not HYDRA_AVAILABLE:
-        logger.info("Hydra configuration features disabled - using fallback implementations")
     
     optional_count = sum(dep_status['optional_dependencies'].values())
     total_optional = len(dep_status['optional_dependencies'])

--- a/tests/analysis/test_analysis_hydra_import.py
+++ b/tests/analysis/test_analysis_hydra_import.py
@@ -1,0 +1,52 @@
+import importlib.util
+import builtins
+import pathlib
+import sys
+import types
+import pytest
+
+
+package_root = pathlib.Path(__file__).resolve().parents[2] / "src/plume_nav_sim"
+module_path = package_root / "analysis" / "__init__.py"
+
+
+def test_import_requires_hydra(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith('hydra') or name.startswith('omegaconf'):
+            raise ImportError('hydra missing')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+    pkg = types.ModuleType("plume_nav_sim")
+    pkg.__path__ = [str(package_root)]
+    sys.modules.setdefault("plume_nav_sim", pkg)
+
+    sys.modules.setdefault("plume_nav_sim.recording", types.ModuleType("plume_nav_sim.recording")).RecorderFactory = object
+    core_mod = types.ModuleType("plume_nav_sim.core")
+    protocols_mod = types.ModuleType("plume_nav_sim.core.protocols")
+    protocols_mod.StatsAggregatorProtocol = object
+    core_mod.protocols = protocols_mod
+    sys.modules.setdefault("plume_nav_sim.core", core_mod)
+    sys.modules.setdefault("plume_nav_sim.core.protocols", protocols_mod)
+
+    stats_mod = types.ModuleType("plume_nav_sim.analysis.stats")
+    stats_mod.StatsAggregator = object
+    stats_mod.StatsAggregatorConfig = object
+    stats_mod.calculate_basic_stats = object
+    stats_mod.calculate_advanced_stats = object
+    stats_mod.create_stats_aggregator = object
+    stats_mod.generate_summary_report = object
+    sys.modules.setdefault("plume_nav_sim.analysis.stats", stats_mod)
+
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.analysis", module_path)
+    module = importlib.util.module_from_spec(spec)
+    with pytest.raises(ImportError):
+        spec.loader.exec_module(module)
+
+
+def test_hydra_flag_removed():
+    source = module_path.read_text()
+    assert 'HYDRA_AVAILABLE' not in source


### PR DESCRIPTION
## Summary
- remove HYDRA_AVAILABLE flag and related fallbacks from analysis module
- drop log message for missing Hydra
- add tests ensuring analysis module requires Hydra and no flag remains

## Testing
- `pytest tests/analysis/test_analysis_hydra_import.py -q`
- `pytest tests/analysis/test_hydra_required.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8eebff1808320a0b37e7f7cf9c447