### PR TITLE
fix: resolve circular imports in utilities

### DIFF
--- a/src/plume_nav_sim/envs/video_plume.py
+++ b/src/plume_nav_sim/envs/video_plume.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for video plume environment.
+
+This module exposes :class:`VideoPlume` from the ``odor_plume_nav`` package
+under the ``plume_nav_sim.envs`` namespace. It enables existing code that
+expects ``plume_nav_sim.envs.video_plume`` to function without requiring a
+separate implementation.
+"""
+
+from odor_plume_nav.environments.video_plume import VideoPlume
+
+__all__ = ["VideoPlume"]

--- a/src/plume_nav_sim/utils/__init__.py
+++ b/src/plume_nav_sim/utils/__init__.py
@@ -16,12 +16,16 @@ CORE_MODULES = [
     "frame_cache",
     "logging_setup",
     "seed_manager",
-    "visualization",
     "io",
-    "navigator_utils",
 ]
 
 __all__: list[str] = []
+
+# Optional submodules loaded on demand to avoid circular imports.
+_OPTIONAL_MODULES = [
+    "visualization",
+    "navigator_utils",
+]
 
 
 def _load_submodule(name: str) -> None:
@@ -37,3 +41,15 @@ def _load_submodule(name: str) -> None:
 
 for _module in CORE_MODULES:
     _load_submodule(_module)
+
+
+def __getattr__(name: str):
+    """Lazily import optional utility submodules."""
+    for module_name in _OPTIONAL_MODULES:
+        module = import_module(f"plume_nav_sim.utils.{module_name}")
+        public = getattr(module, "__all__", [])
+        if name in public:
+            globals().update({attr: getattr(module, attr) for attr in public})
+            __all__.extend(attr for attr in public if attr not in __all__)
+            return getattr(module, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/plume_nav_sim/utils/navigator_utils.py
+++ b/src/plume_nav_sim/utils/navigator_utils.py
@@ -1381,7 +1381,7 @@ def create_navigator_for_cli(
     
     try:
         # Load configuration
-    if config_path:
+        if config_path:
             from hydra import compose, initialize_config_dir
             from pathlib import Path
             

--- a/src/plume_nav_sim/utils/visualization.py
+++ b/src/plume_nav_sim/utils/visualization.py
@@ -65,6 +65,8 @@ try:
 except ImportError as exc:  # pragma: no cover - fail fast
     logger.exception("Failed to import SourceProtocol")
     raise
+else:  # pragma: no cover - just logging
+    logger.info("Successfully imported SourceProtocol")
 
 try:
     from PySide6.QtWidgets import (


### PR DESCRIPTION
## Summary
- lazily load visualization and navigator utilities to avoid circular imports
- log successful SourceProtocol import during visualization setup
- add compatibility wrapper for video plume environment

## Testing
- `pytest src/plume_nav_sim/tests/test_utils.py::TestVisualizationUtilities::test_headless_mode_setup -q` *(fails: plume_nav_sim.core.controllers could not be imported)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5bc22bbc8320aad4af57129ad674