### PR TITLE
fix: require installation before importing package

### DIFF
--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -58,6 +58,16 @@ pip install plume_nav_sim[core]
 pip install plume_nav_sim[all]
 ```
 
+### Development Installation
+To work from a source checkout, install the package in editable mode to ensure
+all dependencies are available:
+
+```bash
+pip install -e .
+# or
+./setup_env.sh --dev
+```
+
 ### Optional Dependency Groups
 
 | Group | Components | Install Command |

--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -21,10 +21,24 @@ import inspect
 import sys
 import atexit
 import logging
+from importlib.metadata import PackageNotFoundError, distribution
 
 __version__ = "1.0.0"
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# INSTALLATION VALIDATION
+# =============================================================================
+try:  # pragma: no cover - exercised in tests via monkeypatch
+    distribution("plume_nav_sim")
+except PackageNotFoundError as e:  # pragma: no cover - executed when not installed
+    msg = (
+        "plume_nav_sim must be installed before use. "
+        "Run 'pip install -e .' or './setup_env.sh --dev'."
+    )
+    logger.error(msg)
+    raise ImportError(msg) from e
 
 # =============================================================================
 # LEGACY GYM DETECTION AND DEPRECATION WARNING SYSTEM

--- a/tests/test_import_requires_installation.py
+++ b/tests/test_import_requires_installation.py
@@ -1,0 +1,18 @@
+import importlib.metadata
+import sys
+
+import pytest
+
+
+def test_import_requires_installation(monkeypatch):
+    """Importing without installed distribution should fail."""
+    from importlib.metadata import PackageNotFoundError
+
+    def fake_distribution(name: str):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "distribution", fake_distribution)
+    sys.modules.pop("plume_nav_sim", None)
+
+    with pytest.raises(ImportError, match="pip install -e"):
+        __import__("plume_nav_sim")


### PR DESCRIPTION
## Summary
- ensure `plume_nav_sim` raises a clear error when imported without installation
- document development installation using `pip install -e .` or `./setup_env.sh --dev`
- test import-time installation check

## Testing
- `pytest tests/test_import_requires_installation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5df0fb348320902a42c66d20c3c8