### PR TITLE
feat: configure logging and warn on stubs

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -21,10 +21,20 @@ import inspect
 import sys
 import atexit
 import logging
+from pathlib import Path
+
+from plume_nav_sim.utils.logging_setup import get_module_logger, setup_logger
 
 __version__ = "1.0.0"
 
-logger = logging.getLogger(__name__)
+_LOGGING_CONFIG = Path(__file__).resolve().parents[2] / "logging.yaml"
+try:  # pragma: no cover - exercised in tests
+    setup_logger(logging_config_path=_LOGGING_CONFIG)
+except Exception:  # pragma: no cover - fall back to basic logging if config fails
+    logging.basicConfig(level=logging.INFO)
+
+logger = get_module_logger(__name__)
+_BOOTSTRAP_COMPLETED = True
 
 # =============================================================================
 # LEGACY GYM DETECTION AND DEPRECATION WARNING SYSTEM
@@ -204,7 +214,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _core_api_available = False
     create_navigator = create_video_plume = run_plume_simulation = visualize_simulation_results = None  # type: ignore
-    logger.error("Failed to import core API functions: %s", e)
+    logger.error(f"Failed to import core API functions: {e}")
 
 # Enhanced API factory functions
 try:
@@ -217,7 +227,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _enhanced_api_available = False
     create_simulation_runner = create_batch_processor = run_experiment_sweep = None  # type: ignore
-    logger.error("Failed to import enhanced API factory functions: %s", e)
+    logger.error(f"Failed to import enhanced API factory functions: {e}")
 
 # Core navigation components
 try:
@@ -232,7 +242,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _core_navigation_available = False
     Navigator = SingleAgentController = MultiAgentController = NavigatorProtocol = run_simulation = None  # type: ignore
-    logger.error("Failed to import core navigation components: %s", e)
+    logger.error(f"Failed to import core navigation components: {e}")
 
 # New v1.0 protocol interfaces for pluggable architecture
 try:
@@ -247,7 +257,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _v1_protocols_available = False
     SourceProtocol = BoundaryPolicyProtocol = ActionInterfaceProtocol = RecorderProtocol = StatsAggregatorProtocol = None  # type: ignore
-    logger.error("Failed to import protocol interfaces: %s", e)
+    logger.error(f"Failed to import protocol interfaces: {e}")
 
 # Environment components
 try:
@@ -257,7 +267,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _env_components_available = False
     VideoPlume = PlumeNavigationEnv = None  # type: ignore
-    logger.error("Failed to import environment components: %s", e)
+    logger.error(f"Failed to import environment components: {e}")
 
 # Configuration management
 try:
@@ -273,7 +283,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _config_available = False
     NavigatorConfig = SingleAgentConfig = MultiAgentConfig = VideoPlumeConfig = load_config = save_config = None  # type: ignore
-    logger.error("Failed to import configuration management components: %s", e)
+    logger.error(f"Failed to import configuration management components: {e}")
 
 # Utility functions
 try:
@@ -298,7 +308,7 @@ except Exception as e:  # pragma: no cover - optional
     _utils_available = False
     load_yaml = save_yaml = load_json = save_json = load_numpy = save_numpy = None  # type: ignore
     setup_logger = get_module_logger = DEFAULT_FORMAT = MODULE_FORMAT = LOG_LEVELS = None  # type: ignore
-    logger.error("Failed to import utility functions: %s", e)
+    logger.error(f"Failed to import utility functions: {e}")
 
 # Gymnasium and RL integration features
 try:
@@ -316,7 +326,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _gymnasium_components_available = False
     GymnasiumEnv = ActionSpace = ObservationSpace = NormalizationWrapper = FrameStackWrapper = RewardShapingWrapper = None  # type: ignore
-    logger.error("Failed to import Gymnasium integration features: %s", e)
+    logger.error(f"Failed to import Gymnasium integration features: {e}")
 
 # Gymnasium environment factory
 try:
@@ -325,7 +335,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _gymnasium_factory_available = False
     create_gymnasium_environment = None  # type: ignore
-    logger.error("Failed to import Gymnasium environment factory: %s", e)
+    logger.error(f"Failed to import Gymnasium environment factory: {e}")
 
 # Shim compatibility layer
 try:
@@ -334,7 +344,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _shim_available = False
     gym_make = None  # type: ignore
-    logger.error("Failed to import shim compatibility layer: %s", e)
+    logger.error(f"Failed to import shim compatibility layer: {e}")
 
 # Recording framework components for v1.0 architecture
 try:
@@ -347,7 +357,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _recording_components_available = False
     BaseRecorder = RecorderFactory = RecorderManager = None  # type: ignore
-    logger.error("Failed to import recording framework components: %s", e)
+    logger.error(f"Failed to import recording framework components: {e}")
 
 # Analysis framework components for v1.0 architecture
 try:
@@ -359,7 +369,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _analysis_components_available = False
     StatsAggregator = generate_summary = None  # type: ignore
-    logger.error("Failed to import analysis framework components: %s", e)
+    logger.error(f"Failed to import analysis framework components: {e}")
 
 # Debug framework components for v1.0 architecture
 try:
@@ -371,7 +381,7 @@ try:
 except Exception as e:  # pragma: no cover - optional
     _debug_components_available = False
     DebugGUI = plot_initial_state = None  # type: ignore
-    logger.error("Failed to import debug framework components: %s", e)
+    logger.error(f"Failed to import debug framework components: {e}")
 
 # Check for stable-baselines3 availability
 try:
@@ -379,7 +389,7 @@ try:
     _stable_baselines3_available = True
 except Exception as e:  # pragma: no cover - optional
     _stable_baselines3_available = False
-    logger.error("stable-baselines3 is required but failed to import: %s", e)
+    logger.error(f"stable-baselines3 is required but failed to import: {e}")
 
 # Check for Gymnasium availability
 try:
@@ -387,7 +397,7 @@ try:
     _gymnasium_available = True
 except Exception as e:  # pragma: no cover - optional
     _gymnasium_available = False
-    logger.error("Gymnasium is required but failed to import: %s", e)
+    logger.error(f"Gymnasium is required but failed to import: {e}")
 
 # =============================================================================
 # FEATURE AVAILABILITY MAPPING

--- a/src/plume_nav_sim/models/wind/__init__.py
+++ b/src/plume_nav_sim/models/wind/__init__.py
@@ -68,11 +68,31 @@ import warnings
 from typing import Dict, Any, List, Optional, Union, Type, Tuple
 from pathlib import Path
 
-from loguru import logger
+import logging
 import numpy as np
 
+from plume_nav_sim.utils.logging_setup import get_module_logger, setup_logger
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 from omegaconf import DictConfig
+
+_CONFIG_PATH = Path(__file__).resolve().parents[4] / "logging.yaml"
+try:  # pragma: no cover - defensive
+    import plume_nav_sim as _root_pkg
+    _bootstrapped = getattr(_root_pkg, "_BOOTSTRAP_COMPLETED", False)
+except Exception:  # pragma: no cover - defensive
+    _bootstrapped = False
+
+if not _bootstrapped:
+    try:  # pragma: no cover - configuration load
+        setup_logger(logging_config_path=_CONFIG_PATH)
+    except Exception:  # pragma: no cover - fallback if config fails
+        logging.basicConfig(level=logging.INFO)
+    logger = get_module_logger(__name__)
+    logger.warning(
+        "Lightweight plume_nav_sim stubs detected; running in limited mode without full package bootstrap.",
+    )
+else:
+    logger = get_module_logger(__name__)
 
 # Import all wind field implementations without graceful fallbacks
 from .constant_wind import ConstantWindField, ConstantWindFieldConfig, create_constant_wind_field

--- a/tests/models/test_wind_stub_warning.py
+++ b/tests/models/test_wind_stub_warning.py
@@ -1,0 +1,70 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2] / "src"
+WIND_INIT = ROOT / "plume_nav_sim" / "models" / "wind" / "__init__.py"
+
+
+def test_lightweight_stub_logs_warning(monkeypatch, capsys):
+    """Importing wind module with package stubs should emit a warning."""
+    # Stub dependencies required during import
+    omegaconf_stub = types.ModuleType("omegaconf")
+    class DummyConfig: ...
+    omegaconf_stub.DictConfig = DummyConfig
+    monkeypatch.setitem(sys.modules, "omegaconf", omegaconf_stub)
+
+    numpy_stub = types.ModuleType("numpy")
+    numpy_typing = types.ModuleType("numpy.typing")
+    numpy_typing.NDArray = object
+    monkeypatch.setitem(sys.modules, "numpy", numpy_stub)
+    monkeypatch.setitem(sys.modules, "numpy.typing", numpy_typing)
+
+    numba_stub = types.ModuleType("numba")
+    numba_stub.jit = lambda *a, **k: (lambda f: f)
+    numba_stub.prange = range
+    monkeypatch.setitem(sys.modules, "numba", numba_stub)
+
+    scipy_stub = types.ModuleType("scipy")
+    scipy_interpolate = types.ModuleType("scipy.interpolate")
+    scipy_signal = types.ModuleType("scipy.signal")
+    scipy_signal.periodogram = lambda *a, **k: ([], [])
+    scipy_interpolate.griddata = lambda *a, **k: None
+    scipy_interpolate.RBFInterpolator = object
+    scipy_stub.interpolate = scipy_interpolate
+    scipy_stub.signal = scipy_signal
+    monkeypatch.setitem(sys.modules, "scipy", scipy_stub)
+    monkeypatch.setitem(sys.modules, "scipy.interpolate", scipy_interpolate)
+    monkeypatch.setitem(sys.modules, "scipy.signal", scipy_signal)
+
+    hydra_stub = types.ModuleType("hydra")
+    hydra_utils = types.ModuleType("hydra.utils")
+    hydra_utils.instantiate = lambda cfg: cfg
+    hydra_stub.utils = hydra_utils
+    monkeypatch.setitem(sys.modules, "hydra", hydra_stub)
+    monkeypatch.setitem(sys.modules, "hydra.utils", hydra_utils)
+
+    pandas_stub = types.ModuleType("pandas")
+    monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
+
+    # Create lightweight package hierarchy to avoid heavy __init__
+    plume_pkg = types.ModuleType("plume_nav_sim")
+    plume_pkg.__path__ = [str(ROOT / "plume_nav_sim")]
+    models_pkg = types.ModuleType("plume_nav_sim.models")
+    models_pkg.__path__ = [str(ROOT / "plume_nav_sim" / "models")]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", plume_pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models", models_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "plume_nav_sim.models.wind", WIND_INIT, submodule_search_locations=[str(WIND_INIT.parent)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind", module)
+
+    spec.loader.exec_module(module)
+
+    captured = capsys.readouterr()
+    assert "limited mode" in captured.err.lower()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,6 @@
+import plume_nav_sim
+from plume_nav_sim.utils.logging_setup import EnhancedLogger
+
+def test_package_uses_enhanced_logger():
+    assert isinstance(plume_nav_sim.logger, EnhancedLogger)
+    assert getattr(plume_nav_sim, "_BOOTSTRAP_COMPLETED", False)


### PR DESCRIPTION
## Summary
- configure logging via logging.yaml during package bootstrap
- warn when lightweight stubs are used instead of full bootstrap
- test for enhanced logger and stub warning

## Testing
- `pytest tests/test_logging_config.py tests/models/test_wind_stub_warning.py -q`
- `pytest -q` *(fails: Database layer is required; ImportError: cannot import name 'ConfigurationError')*


------
https://chatgpt.com/codex/tasks/task_e_68bd5df7cd3c8320babee796a28eaecb