### PR TITLE
refactor: remove stubbed fallbacks

### DIFF
--- a/src/plume_nav_sim/config/utils.py
+++ b/src/plume_nav_sim/config/utils.py
@@ -134,12 +134,6 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         Configuration schema class or None if not found
     """
     schemas = {
-        "navigator": NavigatorConfig,
-        "single_agent": SingleAgentConfig,
-        "multi_agent": MultiAgentConfig,
-        "video_plume": VideoPlumeConfig,
-        "simulation": SimulationConfig,
-        # Class-name keys for convenience
         "NavigatorConfig": NavigatorConfig,
         "SingleAgentConfig": SingleAgentConfig,
         "MultiAgentConfig": MultiAgentConfig,
@@ -147,8 +141,10 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         "SimulationConfig": SimulationConfig,
     }
 
-    # Try exact key first, then lower-case fallback
-    return schemas.get(schema_name) or schemas.get(schema_name.lower())
+    try:
+        return schemas[schema_name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown configuration schema: {schema_name}") from exc
 
 
 def register_config_schemas():

--- a/tests/recording/test_parquet_recorder.py
+++ b/tests/recording/test_parquet_recorder.py
@@ -1,0 +1,19 @@
+"""Tests for ParquetRecorder dependency handling."""
+
+import importlib
+import importlib.metadata
+import sys
+import pytest
+
+
+class _DummyDistribution:
+    version = "0.0"
+
+
+importlib.metadata.distribution = lambda name: _DummyDistribution()
+
+
+def test_parquet_import_requires_pyarrow():
+    sys.modules.pop("plume_nav_sim.recording.backends.parquet", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.recording.backends.parquet")


### PR DESCRIPTION
## Summary
- fail fast when matplotlib.pyplot.subplots returns invalid result
- add regression tests for SimulationVisualization initialization and configuration paths
- drop lowercase fallback when resolving config schemas
- require pyarrow at import time for ParquetRecorder instead of exposing allow_fallback stub

## Testing
- `pytest tests/recording/test_parquet_recorder.py::test_parquet_import_requires_pyarrow -q`
- `pytest tests/visualization/test_trajectory.py::TestSimulationVisualization -q`
- `pytest tests/config/test_config_utils.py::TestConfigStoreIntegration::test_get_config_schema_is_case_sensitive -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd60221080832085a662105fbfc655