### PR TITLE
refactor: remove stubbed fallbacks

### DIFF
--- a/src/plume_nav_sim/config/utils.py
+++ b/src/plume_nav_sim/config/utils.py
@@ -134,12 +134,6 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         Configuration schema class or None if not found
     """
     schemas = {
-        "navigator": NavigatorConfig,
-        "single_agent": SingleAgentConfig,
-        "multi_agent": MultiAgentConfig,
-        "video_plume": VideoPlumeConfig,
-        "simulation": SimulationConfig,
-        # Class-name keys for convenience
         "NavigatorConfig": NavigatorConfig,
         "SingleAgentConfig": SingleAgentConfig,
         "MultiAgentConfig": MultiAgentConfig,
@@ -147,8 +141,10 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         "SimulationConfig": SimulationConfig,
     }
 
-    # Try exact key first, then lower-case fallback
-    return schemas.get(schema_name) or schemas.get(schema_name.lower())
+    try:
+        return schemas[schema_name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown configuration schema: {schema_name}") from exc
 
 
 def register_config_schemas():

--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -785,46 +785,11 @@ class PlumeNavigationEnv(gym.Env):
                 # Legacy mode: use VideoPlumeAdapter with video_path
                 if self._video_path is None:
                     raise ValueError("Either plume_model or video_path must be provided")
-                # If the specified video file does not exist, fall back to a minimal dummy implementation
-                if isinstance(self._video_path, Path) and not self._video_path.exists():
-                    class _DummyVideoPlume:
-                        """Lightweight stand-in for VideoPlumeAdapter used when the file is absent."""
-                        def __init__(self, video_path: str):
-                            self.video_path = video_path
-                            self.frame_count = 1000
-                            self.width = 640
-                            self.height = 480
-                            self.fps = 30.0
-
-                        # --- Minimal API surface expected by the env ---
-                        def concentration_at(self, positions: np.ndarray) -> np.ndarray:
-                            if positions.ndim == 1:
-                                return np.random.rand()
-                            return np.random.rand(len(positions))
-
-                        def step(self, dt: float = 1.0) -> None:
-                            pass
-
-                        def reset(self, **kwargs) -> None:
-                            pass
-
-                        def get_frame(self, frame_id: int) -> Optional[np.ndarray]:
-                            return np.random.rand(self.height, self.width).astype(np.float32)
-
-                        def get_metadata(self) -> Dict[str, Any]:
-                            return {
-                                "width": self.width,
-                                "height": self.height,
-                                "fps": self.fps,
-                                "frame_count": self.frame_count,
-                            }
-
-                        def close(self):
-                            pass
-
-                    self.plume_model = _DummyVideoPlume(str(self._video_path))
-                else:
-                    self.plume_model = VideoPlumeAdapter(str(self._video_path))
+                video_path = Path(self._video_path)
+                if not video_path.exists():
+                    logger.error(f"Video file not found: {video_path}")
+                    raise FileNotFoundError(f"Video file not found: {video_path}")
+                self.plume_model = VideoPlumeAdapter(str(video_path))
             
             # Extract environment dimensions from plume model
             if hasattr(self.plume_model, 'get_metadata'):

--- a/tests/envs/test_fallback_removal.py
+++ b/tests/envs/test_fallback_removal.py
@@ -13,12 +13,22 @@ def load_env_module():
     fake_video_plume = types.ModuleType("plume_nav_sim.models.plume.video_plume")
     fake_video_plume.VideoPlume = object
     sys.modules.setdefault("plume_nav_sim.models.plume.video_plume", fake_video_plume)
+    fake_video_plume_adapter = types.ModuleType("plume_nav_sim.models.plume.video_plume_adapter")
+    fake_video_plume_adapter.VideoPlumeAdapter = object
+    sys.modules.setdefault("plume_nav_sim.models.plume.video_plume_adapter", fake_video_plume_adapter)
     sys.modules.setdefault("pandas", types.ModuleType("pandas"))
     fake_db = types.ModuleType("plume_nav_sim.db.session_manager")
     fake_db.DatabaseSessionManager = object
     sys.modules.setdefault("plume_nav_sim.db.session_manager", fake_db)
+    import importlib.metadata as importlib_metadata
+    class _FakeDist:
+        def locate_file(self, path):
+            return path
+    importlib_metadata.distribution = lambda name: _FakeDist()
     fake_hydra = types.ModuleType("hydra")
     fake_hydra.instantiate = lambda *a, **k: None
+    fake_hydra.compose = lambda *a, **k: None
+    fake_hydra.initialize_config_dir = lambda *a, **k: None
     fake_hydra.utils = types.SimpleNamespace(instantiate=lambda *a, **k: None)
     sys.modules["hydra"] = fake_hydra
     sys.modules["hydra.utils"] = fake_hydra.utils
@@ -67,3 +77,14 @@ def test_unknown_sensor_type_raises(monkeypatch):
     monkeypatch.setattr(env_module, "SPACES_AVAILABLE", False)
     with pytest.raises(ValueError):
         env._init_spaces()
+
+
+def test_missing_video_file_raises(monkeypatch, tmp_path):
+    env_module = load_env_module()
+    env = object.__new__(env_module.PlumeNavigationEnv)
+    env._plume_model_config = None
+    env._video_path = tmp_path / "missing_video.mp4"
+    env._video_frames = None
+    with pytest.raises(RuntimeError) as exc:
+        env._init_plume_model()
+    assert isinstance(exc.value.__cause__, FileNotFoundError)

--- a/tests/recording/test_parquet_recorder.py
+++ b/tests/recording/test_parquet_recorder.py
@@ -1,0 +1,19 @@
+"""Tests for ParquetRecorder dependency handling."""
+
+import importlib
+import importlib.metadata
+import sys
+import pytest
+
+
+class _DummyDistribution:
+    version = "0.0"
+
+
+importlib.metadata.distribution = lambda name: _DummyDistribution()
+
+
+def test_parquet_import_requires_pyarrow():
+    sys.modules.pop("plume_nav_sim.recording.backends.parquet", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.recording.backends.parquet")


### PR DESCRIPTION
## Summary
- fail fast when matplotlib.pyplot.subplots returns invalid result
- add regression tests for SimulationVisualization initialization and configuration paths
- drop lowercase fallback when resolving config schemas
- require pyarrow at import time for ParquetRecorder instead of exposing allow_fallback stub
- raise an error when plume video file is missing instead of using dummy plume

## Testing
- `pytest tests/recording/test_parquet_recorder.py::test_parquet_import_requires_pyarrow -q`
- `pytest tests/visualization/test_trajectory.py::TestSimulationVisualization -q`
- `pytest tests/config/test_config_utils.py::TestConfigStoreIntegration::test_get_config_schema_is_case_sensitive -q`
- `pytest tests/envs/test_fallback_removal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd60221080832085a662105fbfc655