### PR TITLE
refactor: replace native logging with loguru in core

### DIFF
--- a/src/plume_nav_sim/core/__init__.py
+++ b/src/plume_nav_sim/core/__init__.py
@@ -243,14 +243,8 @@ except ImportError:
     HYDRA_AVAILABLE = False
 
 # Enhanced logging support
-try:
-    from loguru import logger
-    LOGURU_AVAILABLE = True
-except ImportError:
-    # Fallback to basic logging
-    import logging
-    logger = logging.getLogger(__name__)
-    LOGURU_AVAILABLE = False
+from loguru import logger
+LOGURU_AVAILABLE = True
 
 
 # Define public API with comprehensive exports for v1.0 architecture
@@ -775,29 +769,24 @@ except Exception as e:
 
 # Configure module-level logging context for enhanced debugging per Section 0.2.1
 try:
-    if LOGURU_AVAILABLE:
-        # Bind core module context for structured logging
-        _module_logger = logger.bind(
-            module="core",
-            version=__version__,
-            gymnasium_migration=True,
-            performance_requirements=__performance_requirements__,
-            compatibility_features=__compatibility_features__
-        )
-        
-        _module_logger.debug(
-            "Core navigation module initialized successfully",
-            exported_components=len(__all__),
-            controllers_available=True,
-            simulation_available=True,
-            hydra_available=HYDRA_AVAILABLE,
-            extensibility_hooks_enabled=True,
-            dual_api_support=True,
-        )
-        
-except ImportError:
-    # Loguru not available - continue without enhanced logging
-    pass
+    _module_logger = logger.bind(
+        module="core",
+        version=__version__,
+        gymnasium_migration=True,
+        performance_requirements=__performance_requirements__,
+        compatibility_features=__compatibility_features__
+    )
+
+    _module_logger.debug(
+        "Core navigation module initialized successfully",
+        exported_components=len(__all__),
+        controllers_available=True,
+        simulation_available=True,
+        hydra_available=HYDRA_AVAILABLE,
+        extensibility_hooks_enabled=True,
+        dual_api_support=True,
+    )
+
 except Exception as e:
     # Log setup failed - continue without structured logging
     warnings.warn(f"Enhanced logging setup failed: {e}", UserWarning, stacklevel=2)

--- a/src/plume_nav_sim/core/actions.py
+++ b/src/plume_nav_sim/core/actions.py
@@ -39,12 +39,11 @@ Examples:
 
 from __future__ import annotations
 from typing import Union, Optional, Dict, Any, Tuple, List
-import logging
 import numpy as np
 
 from .protocols import ActionInterfaceProtocol
+from loguru import logger
 
-logger = logging.getLogger(__name__)
 logger.debug("Loaded actions module with ActionInterfaceProtocol from protocols")
 
 # Gymnasium is a required dependency

--- a/src/plume_nav_sim/core/initialization.py
+++ b/src/plume_nav_sim/core/initialization.py
@@ -50,9 +50,7 @@ from dataclasses import dataclass
 import pandas as pd
 from pathlib import Path
 import warnings
-import logging
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 from .protocols import AgentInitializerProtocol
 

--- a/src/plume_nav_sim/core/navigator.py
+++ b/src/plume_nav_sim/core/navigator.py
@@ -85,9 +85,7 @@ from .protocols import (
 )
 
 # Controller implementations
-import logging
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from .controllers import SingleAgentController, MultiAgentController

--- a/src/plume_nav_sim/core/protocols.py
+++ b/src/plume_nav_sim/core/protocols.py
@@ -32,14 +32,12 @@ from typing_extensions import Self
 import numpy as np
 import warnings
 import inspect
-import logging
+from loguru import logger
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 from plume_nav_sim.protocols import PlumeModelProtocol, SensorProtocol
 
 # Use shared NavigatorProtocol definition
 from plume_nav_sim.protocols.navigator import NavigatorProtocol
-
-logger = logging.getLogger(__name__)
 
 # Hydra imports for configuration integration
 try:

--- a/src/plume_nav_sim/core/sensors/__init__.py
+++ b/src/plume_nav_sim/core/sensors/__init__.py
@@ -152,13 +152,8 @@ except ImportError:
     PERFORMANCE_MONITORING_AVAILABLE = False
 
 # Enhanced logging support
-try:
-    from loguru import logger
-    LOGURU_AVAILABLE = True
-except ImportError:
-    import logging
-    logger = logging.getLogger(__name__)
-    LOGURU_AVAILABLE = False
+from loguru import logger
+LOGURU_AVAILABLE = True
 
 
 # =============================================================================

--- a/src/plume_nav_sim/core/sensors/binary_sensor.py
+++ b/src/plume_nav_sim/core/sensors/binary_sensor.py
@@ -61,27 +61,20 @@ from plume_nav_sim.protocols.sensor import SensorProtocol
 PROTOCOLS_AVAILABLE = True
 
 # Hydra integration for configuration management
-import logging
+from loguru import logger
 
 try:
     from hydra.core.hydra_config import HydraConfig
     from omegaconf import DictConfig, OmegaConf
 except ImportError as e:  # pragma: no cover - dependency required
-    logging.getLogger(__name__).error("hydra-core is required for configuration management", exc_info=e)
-    raise
-
-# Loguru integration for enhanced logging
-try:
-    from loguru import logger
-except ImportError as e:  # pragma: no cover - dependency required
-    logging.getLogger(__name__).error("loguru is required for logging", exc_info=e)
+    logger.error("hydra-core is required for configuration management", exc_info=e)
     raise
 
 # Performance monitoring
 try:
     import psutil
 except ImportError as e:  # pragma: no cover - dependency required
-    logging.getLogger(__name__).error("psutil is required for performance monitoring", exc_info=e)
+    logger.error("psutil is required for performance monitoring", exc_info=e)
     raise
 
 

--- a/src/plume_nav_sim/core/sensors/concentration_sensor.py
+++ b/src/plume_nav_sim/core/sensors/concentration_sensor.py
@@ -71,16 +71,7 @@ from plume_nav_sim.protocols.sensor import SensorProtocol
 # Base sensor infrastructure
 from .base_sensor import BaseSensor
 
-import logging
-
-logger = logging.getLogger(__name__)
-try:
-    from loguru import logger as loguru_logger
-except ImportError as e:
-    logger.error("loguru is required for ConcentrationSensor")
-    raise
-else:
-    logger = loguru_logger
+from loguru import logger
 
 try:
     from omegaconf import DictConfig

--- a/src/plume_nav_sim/core/sensors/gradient_sensor.py
+++ b/src/plume_nav_sim/core/sensors/gradient_sensor.py
@@ -51,7 +51,6 @@ Notes:
     gradient calculations in multi-agent scenarios.
 """
 
-import logging
 import time
 import warnings
 from dataclasses import dataclass, field
@@ -63,15 +62,7 @@ import numpy as np
 # Core protocol imports
 from plume_nav_sim.protocols.sensor import SensorProtocol
 from .base_sensor import BaseSensor
-
-try:  # Fail fast if Loguru is missing
-    from loguru import logger
-except ImportError as exc:  # pragma: no cover - executed only when Loguru is absent
-    logging.getLogger(__name__).error(
-        "loguru is required for GradientSensor but is not installed. "
-        "Install loguru to enable advanced logging."
-    )
-    raise
+from loguru import logger
 
 try:  # Fail fast if Hydra is missing
     from omegaconf import DictConfig, OmegaConf

--- a/src/plume_nav_sim/core/sensors/historical_sensor.py
+++ b/src/plume_nav_sim/core/sensors/historical_sensor.py
@@ -84,13 +84,8 @@ except ImportError:
     OmegaConf = None
 
 # Enhanced logging integration
-try:
-    from loguru import logger
-    LOGURU_AVAILABLE = True
-except ImportError:
-    import logging
-    logger = logging.getLogger(__name__)
-    LOGURU_AVAILABLE = False
+from loguru import logger
+LOGURU_AVAILABLE = True
 
 # Performance monitoring
 try:

--- a/src/plume_nav_sim/core/simulation.py
+++ b/src/plume_nav_sim/core/simulation.py
@@ -70,23 +70,13 @@ from typing import Optional, Tuple, Dict, Any, Union, List, Protocol, TYPE_CHECK
 from plume_nav_sim.protocols.wind_field import WindFieldProtocol
 import numpy as np
 from dataclasses import dataclass, field
-import logging
+from loguru import logger
 
 from ..protocols import PerformanceMonitorProtocol
 from plume_nav_sim.protocols.sensor import SensorProtocol
 from ..models import create_plume_model, create_wind_field
 from .sensors import create_sensor_from_config
 from pathlib import Path
-
-logger = logging.getLogger(__name__)
-
-try:
-    from loguru import logger as _loguru_logger
-except ImportError as exc:
-    logger.error("loguru is required for simulation", exc_info=True)
-    raise
-else:
-    logger = _loguru_logger
 
 try:
     import gymnasium as gym
@@ -747,7 +737,7 @@ class PerformanceMonitor(PerformanceMonitorProtocol):
             raise ValueError("performance_target_ms must be positive")
         self.performance_target_ms = performance_target_ms
         self._durations: Dict[str, List[float]] = {}
-        self._logger = logging.getLogger(__name__)
+        self._logger = logger.bind(component="PerformanceMonitor")
 
     def record_step_time(self, seconds: float, label: str | None = None) -> None:
         if seconds <= 0:
@@ -1073,7 +1063,7 @@ class SimulationContext:
         if self.performance_monitor is not None:
             results.performance_metrics = self.performance_monitor.get_summary()
 
-        logging.getLogger(__name__).info(
+        logger.info(
             "Simulation completed summary: steps=%d, success=%s, performance=%s",
             results.step_count,
             results.success,

--- a/tests/controllers/test_controller_loguru_exclusive.py
+++ b/tests/controllers/test_controller_loguru_exclusive.py
@@ -29,6 +29,24 @@ def test_controller_uses_loguru_exclusively():
     class SpacesFactory: ...
     pkg_envs_spaces.SpacesFactory = SpacesFactory
 
+    pkg_protocols = types.ModuleType('plume_nav_sim.protocols'); pkg_protocols.__path__ = []
+    pkg_protocols_nav = types.ModuleType('plume_nav_sim.protocols.navigator')
+    class NavigatorProtocol: ...
+    pkg_protocols_nav.NavigatorProtocol = NavigatorProtocol
+    pkg_protocols_sensor = types.ModuleType('plume_nav_sim.protocols.sensor')
+    class SensorProtocol: ...
+    pkg_protocols_sensor.SensorProtocol = SensorProtocol
+
+    pkg_core_protocols = types.ModuleType('plume_nav_sim.core.protocols')
+    class BoundaryPolicyProtocol: ...
+    class SourceProtocol: ...
+    pkg_core_protocols.BoundaryPolicyProtocol = BoundaryPolicyProtocol
+    pkg_core_protocols.SourceProtocol = SourceProtocol
+
+    pkg_core_boundaries = types.ModuleType('plume_nav_sim.core.boundaries')
+    def create_boundary_policy(*args, **kwargs): ...
+    pkg_core_boundaries.create_boundary_policy = create_boundary_policy
+
     sys.modules.update({
         'plume_nav_sim': pkg_plume,
         'plume_nav_sim.core': pkg_core,
@@ -38,6 +56,11 @@ def test_controller_uses_loguru_exclusively():
         'plume_nav_sim.utils.frame_cache': pkg_frame_cache,
         'plume_nav_sim.envs': pkg_envs,
         'plume_nav_sim.envs.spaces': pkg_envs_spaces,
+        'plume_nav_sim.protocols': pkg_protocols,
+        'plume_nav_sim.protocols.navigator': pkg_protocols_nav,
+        'plume_nav_sim.protocols.sensor': pkg_protocols_sensor,
+        'plume_nav_sim.core.protocols': pkg_core_protocols,
+        'plume_nav_sim.core.boundaries': pkg_core_boundaries,
     })
 
     spec = importlib.util.spec_from_file_location('plume_nav_sim.core.controllers', module_path)

--- a/tests/logging/test_no_native_logging.py
+++ b/tests/logging/test_no_native_logging.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import ast
+
+
+def test_no_native_logging_in_core():
+    core_dir = Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim" / "core"
+    for file in core_dir.rglob("*.py"):
+        text = file.read_text()
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                assert all(alias.name != "logging" for alias in node.names), f"{file} uses native logging"
+            elif isinstance(node, ast.ImportFrom):
+                assert node.module != "logging", f"{file} uses native logging"

--- a/tests/sensors/test_base_sensor_loguru_exclusive.py
+++ b/tests/sensors/test_base_sensor_loguru_exclusive.py
@@ -17,12 +17,19 @@ def test_base_sensor_uses_loguru_exclusively():
     class SensorConfig: ...
     pkg_schemas.SensorConfig = SensorConfig
 
+    pkg_protocols = types.ModuleType('plume_nav_sim.protocols'); pkg_protocols.__path__ = []
+    pkg_protocols_sensor = types.ModuleType('plume_nav_sim.protocols.sensor')
+    class SensorProtocol: ...
+    pkg_protocols_sensor.SensorProtocol = SensorProtocol
+
     sys.modules.update({
         'plume_nav_sim': pkg_plume,
         'plume_nav_sim.core': pkg_core,
         'plume_nav_sim.core.sensors': pkg_core_sensors,
         'plume_nav_sim.config': pkg_config,
         'plume_nav_sim.config.schemas': pkg_schemas,
+        'plume_nav_sim.protocols': pkg_protocols,
+        'plume_nav_sim.protocols.sensor': pkg_protocols_sensor,
     })
 
     spec = importlib.util.spec_from_file_location('plume_nav_sim.core.sensors.base_sensor', module_path)


### PR DESCRIPTION
## Summary
- add test enforcing loguru-only logging in core modules
- refactor core components to import loguru directly and drop `logging` fallback
- stub protocol dependencies in controller and sensor loguru tests to avoid import errors

## Testing
- `pytest tests/logging/test_no_native_logging.py -q`
- `pytest tests/controllers/test_controller_loguru_exclusive.py tests/sensors/test_base_sensor_loguru_exclusive.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdbb8bc948832081fb79eaf0d909f2