### PR TITLE
refactor: remove stubbed fallbacks

### DIFF
--- a/src/plume_nav_sim/config/utils.py
+++ b/src/plume_nav_sim/config/utils.py
@@ -134,12 +134,6 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         Configuration schema class or None if not found
     """
     schemas = {
-        "navigator": NavigatorConfig,
-        "single_agent": SingleAgentConfig,
-        "multi_agent": MultiAgentConfig,
-        "video_plume": VideoPlumeConfig,
-        "simulation": SimulationConfig,
-        # Class-name keys for convenience
         "NavigatorConfig": NavigatorConfig,
         "SingleAgentConfig": SingleAgentConfig,
         "MultiAgentConfig": MultiAgentConfig,
@@ -147,8 +141,10 @@ def get_config_schema(schema_name: str) -> Optional[Type[BaseModel]]:
         "SimulationConfig": SimulationConfig,
     }
 
-    # Try exact key first, then lower-case fallback
-    return schemas.get(schema_name) or schemas.get(schema_name.lower())
+    try:
+        return schemas[schema_name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown configuration schema: {schema_name}") from exc
 
 
 def register_config_schemas():

--- a/tests/recording/test_hdf5_import.py
+++ b/tests/recording/test_hdf5_import.py
@@ -1,0 +1,62 @@
+"""Tests for HDF5Recorder dependency handling."""
+
+import builtins
+import importlib.util
+import importlib.metadata
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'recording' / 'backends' / 'hdf5.py'
+MODULE_NAME = 'plume_nav_sim.recording.backends.hdf5_test'
+
+
+class _DummyDistribution:
+    version = "0.0"
+
+
+importlib.metadata.distribution = lambda name: _DummyDistribution()
+
+
+@dataclass
+class RecorderConfig:
+    backend: str
+    output_dir: str
+
+
+class BaseRecorder:
+    def __init__(self, config):
+        self.config = config
+
+
+def load_module():
+    pkg = types.ModuleType('plume_nav_sim')
+    pkg.__path__ = []
+    recording_pkg = types.ModuleType('plume_nav_sim.recording')
+    recording_pkg.BaseRecorder = BaseRecorder
+    recording_pkg.RecorderConfig = RecorderConfig
+    sys.modules['plume_nav_sim'] = pkg
+    sys.modules['plume_nav_sim.recording'] = recording_pkg
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def test_hdf5_import_requires_h5py(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'h5py':
+            raise ImportError('No module named h5py')
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    sys.modules.pop(MODULE_NAME, None)
+    with pytest.raises(ImportError):
+        load_module()

--- a/tests/recording/test_parquet_recorder.py
+++ b/tests/recording/test_parquet_recorder.py
@@ -1,0 +1,19 @@
+"""Tests for ParquetRecorder dependency handling."""
+
+import importlib
+import importlib.metadata
+import sys
+import pytest
+
+
+class _DummyDistribution:
+    version = "0.0"
+
+
+importlib.metadata.distribution = lambda name: _DummyDistribution()
+
+
+def test_parquet_import_requires_pyarrow():
+    sys.modules.pop("plume_nav_sim.recording.backends.parquet", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.recording.backends.parquet")


### PR DESCRIPTION
## Summary
- fail when configuration requires NavigatorFactory but it's unavailable
- refuse to auto-inject dummy video paths; require explicit plume_model or video_path
- add regression tests for missing dependencies and video paths
- require h5py for HDF5Recorder import and test that missing h5py raises ImportError

## Testing
- `pytest tests/recording/test_hdf5_import.py::test_hdf5_import_requires_h5py -q`
- `pytest tests/recording/test_parquet_recorder.py::test_parquet_import_requires_pyarrow -q`
- `pytest tests/visualization/test_trajectory.py::TestSimulationVisualization -q`
- `pytest tests/config/test_config_utils.py::TestConfigStoreIntegration::test_get_config_schema_is_case_sensitive -q`
- `pytest tests/envs/test_fallback_removal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd60221080832085a662105fbfc655