### PR TITLE
fix: enforce dependency imports

### DIFF
--- a/src/plume_nav_sim/envs/__init__.py
+++ b/src/plume_nav_sim/envs/__init__.py
@@ -45,13 +45,11 @@ HYDRA_INSTANTIATE_AVAILABLE = True
 # Required core environment
 try:
     from plume_nav_sim.envs.video_plume import VideoPlume
-    VIDEO_PLUME_AVAILABLE = True
-except ImportError as e:  # pragma: no cover - optional dependency
-    logger.error(f"VideoPlume import failed: {e}")
-    VideoPlume = None  # type: ignore
-    VIDEO_PLUME_AVAILABLE = False
+except ImportError as e:  # pragma: no cover - fail fast
+    logger.error("VideoPlume import failed", exc_info=e)
+    raise
 
-# List of all available exports - will be updated based on successful imports
+# List of all available exports
 __all__ = ["VideoPlume"]
 
 # Check for legacy gym import attempts and issue deprecation warnings
@@ -100,7 +98,6 @@ except ImportError as e:  # pragma: no cover - explicit failure
 try:
     from plume_nav_sim.envs.plume_navigation_env import PlumeNavigationEnv
     __all__.append("PlumeNavigationEnv")
-    PLUME_ENV_AVAILABLE = True
     logger.info(
         "PlumeNavigationEnv available with extensibility hooks",
         extra={
@@ -110,17 +107,9 @@ try:
             "frame_cache_support": True
         }
     ) if LOGGING_AVAILABLE else None
-except ImportError as e:
-    PlumeNavigationEnv = None
-    PLUME_ENV_AVAILABLE = False
-    logger.warning(
-        f"PlumeNavigationEnv not available: {e}",
-        extra={
-            "metric_type": "environment_limitation",
-            "missing_component": "plume_navigation_env",
-            "error": str(e)
-        }
-    ) if LOGGING_AVAILABLE else None
+except ImportError as e:  # pragma: no cover - fail fast
+    logger.error("PlumeNavigationEnv import failed", exc_info=e)
+    raise
 
 # Minimal reference environment for testing
 try:

--- a/src/plume_nav_sim/utils/visualization.py
+++ b/src/plume_nav_sim/utils/visualization.py
@@ -78,20 +78,15 @@ try:
     )
     from PySide6.QtCore import QTimer, Signal, QThread
     from PySide6.QtGui import QPixmap, QPainter
-    PYSIDE6_AVAILABLE = True
-except ImportError as exc:  # pragma: no cover - optional dependency
-    PYSIDE6_AVAILABLE = False
-    logger.warning("PySide6 is required for interactive visualization", exc_info=exc)
-    QApplication = QMainWindow = QWidget = QVBoxLayout = QHBoxLayout = None  # type: ignore
-    QTimer = Signal = QThread = QPixmap = QPainter = None  # type: ignore
+except ImportError as exc:  # pragma: no cover - fail fast
+    logger.error("PySide6 is required for interactive visualization", exc_info=exc)
+    raise
 
 try:
     import streamlit as st
-    STREAMLIT_AVAILABLE = True
-except ImportError as exc:  # pragma: no cover - optional dependency
-    STREAMLIT_AVAILABLE = False
-    logger.warning("Streamlit is not installed; streamlit-based visualization disabled", exc_info=exc)
-    st = None  # type: ignore
+except ImportError as exc:  # pragma: no cover - fail fast
+    logger.error("Streamlit is required for streamlit-based visualization", exc_info=exc)
+    raise
 
 try:
     from hydra.core.config_store import ConfigStore

--- a/tests/envs/test_env_module_dependencies.py
+++ b/tests/envs/test_env_module_dependencies.py
@@ -1,0 +1,49 @@
+import importlib
+import builtins
+import sys
+import importlib.metadata as importlib_metadata
+
+import pytest
+
+MODULE = "plume_nav_sim.envs"
+
+
+def _patch_distribution(monkeypatch):
+    class _FakeDist:
+        def locate_file(self, path):
+            return path
+    monkeypatch.setattr(importlib_metadata, "distribution", lambda name: _FakeDist())
+
+
+def test_import_requires_video_plume(monkeypatch):
+    _patch_distribution(monkeypatch)
+    monkeypatch.delitem(sys.modules, MODULE, raising=False)
+    monkeypatch.delitem(sys.modules, f"{MODULE}.video_plume", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == f"{MODULE}.video_plume":
+            raise ImportError("VideoPlume not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(MODULE)
+
+
+def test_import_requires_plume_navigation_env(monkeypatch):
+    _patch_distribution(monkeypatch)
+    monkeypatch.delitem(sys.modules, MODULE, raising=False)
+    monkeypatch.delitem(sys.modules, f"{MODULE}.plume_navigation_env", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == f"{MODULE}.plume_navigation_env":
+            raise ImportError("PlumeNavigationEnv not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(MODULE)


### PR DESCRIPTION
## Summary
- fail fast when core env modules are missing
- require GUI frameworks for visualization utilities
- add regression tests for env import errors

## Testing
- `pytest tests/envs/test_env_module_dependencies.py -q`
- `pytest tests/utils/test_visualization_imports.py::test_import_fails_when_dependency_missing -q`
- `pytest tests/debug/test_gui_import.py::test_import_requires_pyside6 -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf2c4ff7c8320bbba870912739472