### PR TITLE
refactor: remove logging stub fallback

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -23,27 +23,14 @@ import atexit
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, distribution
 
-try:  # Prefer Loguru when available
-    from loguru import logger as _logger
-    _LOGGER_IS_STUB = not hasattr(_logger, "configure")
-    logger = _logger
-except Exception:  # pragma: no cover - defensive fallback
-    import logging as _logging
-    logger = _logging.getLogger(__name__)
-    _LOGGER_IS_STUB = True
+from loguru import logger as logger
+
+if not hasattr(logger, "configure"):
+    raise ImportError("loguru.logger missing 'configure'; install full loguru package")
 
 
 def _configure_logger() -> None:
-    """Configure logging from logging.yaml or warn if running in stub mode."""
-    if _LOGGER_IS_STUB:
-        try:
-            logger.warning(
-                "Logging bootstrap not available; running in limited mode with lightweight stubs."
-            )
-        except Exception:  # pragma: no cover - safety
-            pass
-        return
-
+    """Configure logging from logging.yaml using loguru."""
     from .utils.logging_setup import setup_logger
 
     config_path = Path(__file__).resolve().parents[2] / "logging.yaml"

--- a/tests/test_logging_stub_warning.py
+++ b/tests/test_logging_stub_warning.py
@@ -1,37 +1,18 @@
 import sys
 import types
 import importlib.metadata
+import pytest
 
 
 def _install_loguru_stub(monkeypatch):
-    messages = []
+    """Install a loguru stub lacking required features."""
     loguru_stub = types.ModuleType("loguru")
 
     class StubLogger:
-        def warning(self, msg, *args, **kwargs):
-            messages.append(msg)
-
-        def info(self, *args, **kwargs):
-            pass
-
-        def debug(self, *args, **kwargs):
-            pass
-
-        def error(self, *args, **kwargs):
-            pass
-
-        def remove(self, *args, **kwargs):
-            pass
-
-        def add(self, *args, **kwargs):
-            return 0
-
-        def bind(self, *args, **kwargs):
-            return self
+        """Minimal logger without configure support."""
 
     loguru_stub.logger = StubLogger()
     monkeypatch.setitem(sys.modules, "loguru", loguru_stub)
-    return messages
 
 
 def _patch_distribution(monkeypatch):
@@ -49,33 +30,11 @@ def _patch_distribution(monkeypatch):
     monkeypatch.setattr(importlib.metadata, "distribution", fake_distribution)
 
 
-def test_root_warns_on_stub(monkeypatch):
-    messages = _install_loguru_stub(monkeypatch)
+def test_import_fails_with_loguru_stub(monkeypatch):
+    """Importing with a loguru stub should raise ImportError."""
+    _install_loguru_stub(monkeypatch)
     _patch_distribution(monkeypatch)
     sys.modules.pop("plume_nav_sim", None)
 
-    import plume_nav_sim  # noqa: F401
-
-    assert any("limited" in m for m in messages)
-
-
-def test_wind_warns_on_stub(monkeypatch):
-    messages = _install_loguru_stub(monkeypatch)
-    _patch_distribution(monkeypatch)
-    sys.modules.pop("plume_nav_sim", None)
-
-    import plume_nav_sim  # noqa: F401
-    messages.clear()
-
-    import types
-    numba_stub = types.ModuleType("numba")
-    numba_stub.jit = lambda *a, **k: (lambda f: f)
-    numba_stub.prange = range
-    monkeypatch.setitem(sys.modules, "numba", numba_stub)
-
-    pandas_stub = types.ModuleType("pandas")
-    monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
-
-    import plume_nav_sim.models.wind  # noqa: F401
-
-    assert any("limited" in m for m in messages)
+    with pytest.raises(ImportError, match="loguru.*configure"):
+        import plume_nav_sim  # noqa: F401


### PR DESCRIPTION
## Summary
- drop fallback to stub logging when loguru is unavailable
- raise ImportError when loguru lacks configure and streamline logger setup
- update tests to require loguru and ensure import failure with stub

## Testing
- `pytest tests/test_logging_stub_warning.py::test_import_fails_with_loguru_stub -q`
- `pytest tests/api/test_loguru_hydra_required.py::test_import_requires_loguru_and_hydra -q`
- `pytest tests/models/test_wind_registry_logging.py::test_loguru_absence_raises_import_error -q`
- `pytest tests/utils/test_seed_utils_logging.py::test_importerror_when_loguru_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee5a17e708320ba5ecdbc697ae790