### PR TITLE
refactor: remove logging fallbacks

### DIFF
--- a/src/plume_nav_sim/debug/gui.py
+++ b/src/plume_nav_sim/debug/gui.py
@@ -68,17 +68,10 @@ from plume_nav_sim.envs.plume_navigation_env import PlumeNavigationEnv
 try:
     from plume_nav_sim.utils.logging_setup import get_module_logger
     logger = get_module_logger(__name__)
-except ImportError:  # pragma: no cover - fallback for logging setup import
-    import logging
-    logger = logging.getLogger(__name__)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
+except ImportError as exc:  # pragma: no cover - fail fast on missing logging setup
+    raise ImportError(
+        "plume_nav_sim.utils.logging_setup is required for debug GUI logging"
+    ) from exc
 
 # Import required GUI dependencies
 try:

--- a/src/plume_nav_sim/models/wind/__init__.py
+++ b/src/plume_nav_sim/models/wind/__init__.py
@@ -71,8 +71,8 @@ from pathlib import Path
 from loguru import logger
 
 if not hasattr(logger, "configure"):
-    logger.warning(
-        "Wind models running with lightweight logging stubs; functionality is limited."
+    raise ImportError(
+        "loguru.logger missing 'configure'; install full loguru package"
     )
 import numpy as np
 

--- a/tests/debug/test_gui_import.py
+++ b/tests/debug/test_gui_import.py
@@ -1,6 +1,8 @@
 import importlib
 import builtins
 import sys
+import types
+from pathlib import Path
 
 import pytest
 
@@ -20,4 +22,38 @@ def test_import_requires_pyside6(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     with pytest.raises(ImportError):
+        importlib.import_module("plume_nav_sim.debug.gui")
+
+
+def test_import_requires_logging_setup(monkeypatch):
+    """Debug GUI import should fail without logging setup module."""
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.utils.logging_setup", raising=False)
+    monkeypatch.delitem(sys.modules, "plume_nav_sim.debug.gui", raising=False)
+
+    root = Path(__file__).resolve().parents[2] / "src"
+    plume_pkg = types.ModuleType("plume_nav_sim")
+    plume_pkg.__path__ = [str(root / "plume_nav_sim")]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", plume_pkg)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "plume_nav_sim.utils.logging_setup":
+            raise ImportError("logging setup missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    pyside_stub = types.ModuleType("PySide6")
+    monkeypatch.setitem(sys.modules, "PySide6", pyside_stub)
+    for sub in ["QtCore", "QtWidgets", "QtGui"]:
+        monkeypatch.setitem(sys.modules, f"PySide6.{sub}", types.ModuleType(f"PySide6.{sub}"))
+
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.use = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib_stub)
+    monkeypatch.setitem(sys.modules, "matplotlib.backends.backend_qt5agg", types.ModuleType("backend_qt5agg"))
+    monkeypatch.setitem(sys.modules, "matplotlib.figure", types.ModuleType("figure"))
+
+    with pytest.raises(ImportError, match="logging setup"):
         importlib.import_module("plume_nav_sim.debug.gui")

--- a/tests/models/test_wind_logging_stub_error.py
+++ b/tests/models/test_wind_logging_stub_error.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2] / "src"
+WIND_INIT = ROOT / "plume_nav_sim" / "models" / "wind" / "__init__.py"
+
+
+def test_import_fails_with_loguru_stub(monkeypatch):
+    """Wind module import should error if loguru lacks configure."""
+    loguru_stub = types.ModuleType("loguru")
+    loguru_stub.logger = types.SimpleNamespace(
+        warning=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "loguru", loguru_stub)
+
+    plume_pkg = types.ModuleType("plume_nav_sim")
+    plume_pkg.__path__ = [str(ROOT / "plume_nav_sim")]
+    models_pkg = types.ModuleType("plume_nav_sim.models")
+    models_pkg.__path__ = [str(ROOT / "plume_nav_sim" / "models")]
+    monkeypatch.setitem(sys.modules, "plume_nav_sim", plume_pkg)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models", models_pkg)
+
+    const_stub = types.ModuleType("plume_nav_sim.models.wind.constant_wind")
+    const_stub.ConstantWindField = object
+    const_stub.ConstantWindFieldConfig = object
+    const_stub.create_constant_wind_field = lambda *a, **k: None
+    turb_stub = types.ModuleType("plume_nav_sim.models.wind.turbulent_wind")
+    turb_stub.TurbulentWindField = object
+    turb_stub.TurbulentWindFieldConfig = object
+    time_stub = types.ModuleType("plume_nav_sim.models.wind.time_varying_wind")
+    time_stub.TimeVaryingWindField = object
+    time_stub.TimeVaryingWindFieldConfig = object
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind.constant_wind", const_stub)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind.turbulent_wind", turb_stub)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind.time_varying_wind", time_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "plume_nav_sim.models.wind", WIND_INIT, submodule_search_locations=[str(WIND_INIT.parent)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "plume_nav_sim.models.wind", module)
+
+    with pytest.raises(ImportError, match="loguru"):
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- remove silent logger fallbacks in debug GUI
- enforce full loguru support for wind models
- add tests to assert imports fail when dependencies are missing

## Testing
- `pytest tests/debug/test_gui_import.py::test_import_requires_pyside6 tests/debug/test_gui_import.py::test_import_requires_logging_setup tests/models/test_wind_logging_stub_error.py::test_import_fails_with_loguru_stub -q`

------
https://chatgpt.com/codex/tasks/task_e_68bef273d830832095ffe76fc7541bba