### PR TITLE
refactor: remove placeholder fallbacks

### DIFF
--- a/src/plume_nav_sim/data/video_plume.py
+++ b/src/plume_nav_sim/data/video_plume.py
@@ -232,9 +232,9 @@ class VideoPlume:
         Returns:
             Concentration value at the specified position
         """
-        # This is a placeholder implementation
-        # In a real implementation, this would extract concentration from the current frame
-        return 0.0
+        raise NotImplementedError(
+            "concentration extraction from video frames is not implemented"
+        )
 
     @property
     def duration(self) -> float:

--- a/src/plume_nav_sim/envs/plume_navigation_env.py
+++ b/src/plume_nav_sim/envs/plume_navigation_env.py
@@ -2090,14 +2090,16 @@ class PlumeNavigationEnv(gym.Env):
                     observation[f"sensor_{i}_{sensor_name}_direction"] = np.array([direction], dtype=np.float32)
                     
                 else:
-                    # Generic sensor - use detect method or fallback
+                    # Generic sensor must implement detect or measure
                     if hasattr(sensor, 'detect'):
                         reading = sensor.detect(concentration_array, agent_positions)
                     elif hasattr(sensor, 'measure'):
                         reading = sensor.measure(concentration_array, agent_positions)
                     else:
-                        reading = concentration_array  # Fallback
-                    
+                        raise AttributeError(
+                            f"Sensor {sensor_name} must implement 'detect' or 'measure'"
+                        )
+
                     if hasattr(reading, '__len__') and len(reading) == 1:
                         reading = reading[0]
                     observation[f"sensor_{i}_{sensor_name}_output"] = np.array([reading], dtype=np.float32)

--- a/src/plume_nav_sim/tests/test_video_plume.py
+++ b/src/plume_nav_sim/tests/test_video_plume.py
@@ -1,0 +1,33 @@
+"""Tests for VideoPlume data handling."""
+
+from pathlib import Path
+import types
+import sys
+import pytest
+
+# Provide stub for ConfigurationError to avoid circular import during testing
+stub_api_nav = types.ModuleType("plume_nav_sim.api.navigation")
+class ConfigurationError(Exception):
+    pass
+stub_api_nav.ConfigurationError = ConfigurationError
+sys.modules.setdefault("plume_nav_sim.api.navigation", stub_api_nav)
+
+from plume_nav_sim.data.video_plume import VideoPlume
+
+
+class DummyVideoPlume(VideoPlume):
+    """VideoPlume subclass that skips video capture for testing."""
+    def _init_video_capture(self):  # type: ignore[override]
+        self._cap = None
+        self.frame_count = 1
+        self.width = 1
+        self.height = 1
+        self.fps = 1.0
+
+
+def test_get_concentration_not_implemented():
+    """get_concentration should raise until implemented."""
+    video_path = Path('test_video.mp4').resolve()
+    vp = DummyVideoPlume(video_path=video_path)
+    with pytest.raises(NotImplementedError):
+        vp.get_concentration((0, 0))


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` in `VideoPlume.get_concentration` instead of returning a placeholder value
- enforce sensor interface requirements in `PlumeNavigationEnv`
- add regression test for `VideoPlume.get_concentration`

## Testing
- `pytest src/plume_nav_sim/tests/test_video_plume.py::test_get_concentration_not_implemented -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef499798083208b46b86c711386e1