### PR TITLE
fix(core): validate env array in odor value reader

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -2476,10 +2476,12 @@ def _read_odor_values(env_array: np.ndarray, positions: np.ndarray) -> np.ndarra
     if hasattr(env_array, 'current_frame'):
         env_array = env_array.current_frame
 
-    # Get dimensions of environment array
+    # Validate environment array structure
     if not hasattr(env_array, 'shape') or len(env_array.shape) < 2:
-        # For mock objects in tests or arrays without shape
-        return np.zeros(len(positions))
+        logger.error("Invalid env_array passed to _read_odor_values", env_array=env_array)
+        raise ValueError(
+            "env_array must have a 'shape' attribute with at least two dimensions"
+        )
 
     height, width = env_array.shape[:2]
     num_positions = positions.shape[0]

--- a/tests/test_read_odor_values.py
+++ b/tests/test_read_odor_values.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+import ast
+from pathlib import Path
+
+class _DummyLogger:
+    def error(self, *args, **kwargs):
+        pass
+
+# Extract _read_odor_values function from controllers.py without importing package
+source_path = Path(__file__).resolve().parents[1] / "src" / "plume_nav_sim" / "core" / "controllers.py"
+source = source_path.read_text()
+module = ast.parse(source)
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == "_read_odor_values":
+        func_module = ast.Module([node], [])
+        ast.fix_missing_locations(func_module)
+        namespace: dict = {}
+        exec(
+            compile(func_module, filename=str(source_path), mode="exec"),
+            {"np": np, "logger": _DummyLogger()},
+            namespace,
+        )
+        _read_odor_values = namespace["_read_odor_values"]
+        break
+else:
+    raise RuntimeError("_read_odor_values not found")
+
+
+def test_invalid_env_array_raises():
+    positions = np.array([[0, 0]])
+    with pytest.raises(ValueError):
+        _read_odor_values(object(), positions)


### PR DESCRIPTION
## Summary
- raise `ValueError` when `_read_odor_values` receives a non-array environment
- add regression test for invalid environment arrays

## Testing
- `pytest tests/test_read_odor_values.py::test_invalid_env_array_raises -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef661ad3c83209f1d0bdf1def513c