### PR TITLE
refactor(recording): drop h5py fallback for HDF5Recorder

### DIFF
--- a/src/plume_nav_sim/recording/backends/hdf5.py
+++ b/src/plume_nav_sim/recording/backends/hdf5.py
@@ -13,7 +13,6 @@ Key Features:
     - Compression support (gzip, lzf, szip) with configurable chunk sizes for time-series data
     - Structured group hierarchy (/run_id/episode_id/datasets) for scalable multi-experiment organization
     - Attribute metadata preservation with HDF5 attributes for experimental parameters
-    - Graceful fallback when h5py dependencies are unavailable per optional dependency handling
 
 Performance Characteristics:
     - F-017-RQ-001: <1ms overhead per 1000 steps when disabled for minimal simulation impact
@@ -64,17 +63,10 @@ from queue import Queue
 from typing import Dict, Any, Optional, Union, List, Tuple, TYPE_CHECKING
 
 import numpy as np
+import h5py  # type: ignore
 
 # Import BaseRecorder from recording framework
 from .. import BaseRecorder, RecorderConfig
-
-# HDF5 dependency required
-_H5PY_IMPORT_ERROR = None
-try:
-    import h5py  # type: ignore
-except ImportError as _h5_err:  # pragma: no cover - dependency validation
-    h5py = None  # type: ignore
-    _H5PY_IMPORT_ERROR = _h5_err
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -272,10 +264,6 @@ class HDF5Recorder(BaseRecorder):
                 compression=config.compression if config.compression != 'none' else None,
                 buffer_size=config.buffer_size
             )
-        
-        # Validate h5py dependency
-        if h5py is None:  # pragma: no cover - defensive
-            raise ImportError("h5py is required for HDF5Recorder") from _H5PY_IMPORT_ERROR
         
         # HDF5-specific state
         self._h5_file: Optional["h5py.File"] = None

--- a/tests/recording/test_hdf5_backend.py
+++ b/tests/recording/test_hdf5_backend.py
@@ -67,19 +67,19 @@ def test_hdf5_recorder_normal_operation(tmp_path, monkeypatch):
     assert episode_dir.exists() or True  # minimal check
 
 
-def test_missing_h5py_raises_import_error(monkeypatch, tmp_path):
+def test_missing_h5py_raises_import_error(monkeypatch):
+    """HDF5 module import should fail when h5py is unavailable."""
     original_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == 'h5py':
-            raise ImportError('No module named h5py')
+        if name == "h5py":
+            raise ImportError("No module named h5py")
         return original_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
     if MODULE_NAME in sys.modules:
         del sys.modules[MODULE_NAME]
-    module = load_module(monkeypatch)
-    HDF5Recorder = module.HDF5Recorder
-
     with pytest.raises(ImportError):
-        HDF5Recorder(RecorderConfig(backend='hdf5', output_dir=str(tmp_path)))
+        load_module(monkeypatch)
+    sys.modules.pop("plume_nav_sim.recording", None)
+    sys.modules.pop("plume_nav_sim", None)


### PR DESCRIPTION
## Summary
- remove h5py import fallback in HDF5Recorder backend to fail fast when dependency missing
- adjust HDF5 backend test to expect ImportError during module import when h5py is absent

## Testing
- `pytest tests/recording/test_hdf5_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef919576c8320bca75d52488d8eb6