### PR TITLE
refactor: remove test fallbacks

### DIFF
--- a/src/plume_nav_sim/data/video_plume.py
+++ b/src/plume_nav_sim/data/video_plume.py
@@ -13,7 +13,6 @@ from typing import Optional, Union, Any, Dict
 import cv2
 import numpy as np
 from loguru import logger
-from plume_nav_sim.api.navigation import ConfigurationError
 from odor_plume_nav.data.video_plume import VIDEO_FILE_MISSING_MSG
 from plume_nav_sim.utils.logging_setup import get_correlation_context
 
@@ -148,8 +147,9 @@ class VideoPlume:
     def _init_video_capture(self):
         """Initialize the OpenCV VideoCapture and validate it can be opened."""
         self._cap = cv2.VideoCapture(str(self.video_path))
-        
+
         if not self._cap.isOpened():
+            from plume_nav_sim.api.navigation import ConfigurationError
             raise ConfigurationError(f"Failed to open video file: {self.video_path}")
         
         # Store video properties

--- a/src/plume_nav_sim/tests/test_utils.py
+++ b/src/plume_nav_sim/tests/test_utils.py
@@ -65,12 +65,7 @@ setup_headless_mode = visualization.setup_headless_mode
 get_available_themes = visualization.get_available_themes
 DEFAULT_VISUALIZATION_CONFIG = visualization.DEFAULT_VISUALIZATION_CONFIG
 
-# Try to import enhanced logging, fallback if not available
-try:
-    import psutil
-    PSUTIL_AVAILABLE = True
-except ImportError:
-    PSUTIL_AVAILABLE = False
+import psutil
 
 
 class TestFrameCache:
@@ -215,7 +210,6 @@ class TestFrameCache:
         if cache.statistics:
             assert cache.statistics._evictions > 0
     
-    @pytest.mark.skipif(not PSUTIL_AVAILABLE, reason="psutil not available for memory monitoring")
     def test_memory_pressure_monitoring(self):
         """Test memory pressure monitoring with PSUtil integration."""
         cache = FrameCache(
@@ -858,7 +852,6 @@ class TestUtilityIntegration:
 
             plt.close(fig)
     
-    @pytest.mark.skipif(not PSUTIL_AVAILABLE, reason="psutil not available")
     def test_memory_management_integration(self):
         """Test memory management across utility components."""
         process = psutil.Process()

--- a/src/plume_nav_sim/tests/test_video_plume.py
+++ b/src/plume_nav_sim/tests/test_video_plume.py
@@ -1,17 +1,9 @@
 """Tests for VideoPlume data handling."""
 
 from pathlib import Path
-import types
-import sys
 import pytest
 
-# Provide stub for ConfigurationError to avoid circular import during testing
-stub_api_nav = types.ModuleType("plume_nav_sim.api.navigation")
-class ConfigurationError(Exception):
-    pass
-stub_api_nav.ConfigurationError = ConfigurationError
-sys.modules.setdefault("plume_nav_sim.api.navigation", stub_api_nav)
-
+from plume_nav_sim.api.navigation import ConfigurationError
 from plume_nav_sim.data.video_plume import VideoPlume
 
 
@@ -31,3 +23,8 @@ def test_get_concentration_not_implemented():
     vp = DummyVideoPlume(video_path=video_path)
     with pytest.raises(NotImplementedError):
         vp.get_concentration((0, 0))
+
+
+def test_real_navigation_module_loaded():
+    import plume_nav_sim.api.navigation as nav
+    assert hasattr(nav, "create_navigator")


### PR DESCRIPTION
## Summary
- remove psutil import fallbacks in utility tests
- drop navigation stub and ensure real module loads
- load ConfigurationError lazily to avoid circular imports

## Testing
- `./setup_env.sh --dev` *(fails: No such file or directory)*
- `PYTHONPATH=src python - <<'PY'
import importlib.metadata
_real = importlib.metadata.distribution
class FakeDist:
    def locate_file(self, path):
        return path

def fake_distribution(name):
    if name == "plume_nav_sim":
        return FakeDist()
    return _real(name)

importlib.metadata.distribution = fake_distribution

import pytest, sys
res = pytest.main(["src/plume_nav_sim/tests/test_video_plume.py::test_real_navigation_module_loaded", "-q"])
sys.exit(res)
PY`
- `PYTHONPATH=src python - <<'PY'
import importlib.metadata
_real = importlib.metadata.distribution
class FakeDist:
    def locate_file(self, path):
        return path

def fake_distribution(name):
    if name == "plume_nav_sim":
        return FakeDist()
    return _real(name)

importlib.metadata.distribution = fake_distribution

import pytest, sys
res = pytest.main(["-q"])
sys.exit(res)
PY` *(fails: ModuleNotFoundError: No module named 'PySide6'; ModuleNotFoundError: No module named 'numba'; ImportError: Database layer is required for plume_nav_sim CLI. Install with 'pip install plume_nav_sim[db]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf013bcdc88320b1794400e1a4b0bb