### PR TITLE
refactor: remove stubbed fallbacks

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -631,19 +631,15 @@ class BaseController:
         )
 
     def get_observation_space_info(self) -> Dict[str, Any]:
-        """Return basic observation space metadata.
-
-        This stub provides minimal information required by tests and can be
-        extended by subclasses for richer observation descriptions.
-
-        Returns:
-            Dict[str, Any]: Dictionary with observation space details.
-        """
-        info = {
-            "num_agents": getattr(self, "num_agents", 0),
-            "sensors": [type(s).__name__ for s in getattr(self, "_sensors", [])],
+        """Return basic observation space metadata."""
+        if not hasattr(self, "num_agents"):
+            raise AttributeError("Controller must define 'num_agents'")
+        if not hasattr(self, "_sensors"):
+            raise AttributeError("Controller must define '_sensors'")
+        return {
+            "num_agents": self.num_agents,
+            "sensors": [type(s).__name__ for s in self._sensors],
         }
-        return info
     
     def get_performance_metrics(self) -> Dict[str, Any]:
         """

--- a/src/plume_nav_sim/utils/visualization.py
+++ b/src/plume_nav_sim/utils/visualization.py
@@ -1259,7 +1259,7 @@ def plot_initial_state(
 
 
 def create_debug_visualizer(
-    backend: Literal['qt', 'streamlit', 'auto'] = 'auto',
+    backend: Literal['qt', 'streamlit'] = 'qt',
     real_time_updates: bool = True,
     performance_monitoring: bool = True,
     state_inspection: bool = True,
@@ -1275,7 +1275,7 @@ def create_debug_visualizer(
     parameter manipulation, and performance monitoring capabilities for advanced debugging workflows.
     
     Args:
-        backend: GUI backend selection ('qt', 'streamlit', 'auto' for automatic fallback).
+        backend: GUI backend selection ('qt' or 'streamlit').
         real_time_updates: Enable real-time visualization updates during simulation.
         performance_monitoring: Include performance metrics and profiling tools.
         state_inspection: Enable detailed agent state and sensor reading inspection.
@@ -1304,12 +1304,6 @@ def create_debug_visualizer(
         ... )
         >>> debugger.launch_web_interface(port=8501)
         
-        Auto-fallback with full features:
-        >>> debugger = create_debug_visualizer(
-        ...     backend='auto',
-        ...     performance_monitoring=True,
-        ...     parameter_controls=True
-        ... )
     """
     logger.info(f"Creating debug visualizer with backend: {backend}")
     
@@ -1319,15 +1313,11 @@ def create_debug_visualizer(
     logger.debug("PySide6 available for Qt backend")
     logger.debug("Streamlit available for web backend")
 
-    if backend == 'auto':
-        selected_backend = 'qt'
-    else:
-        if backend not in available_backends and backend != 'console':
-            raise ImportError(
-                f"Requested backend '{backend}' not available. "
-                f"Available backends: {available_backends}"
-            )
-        selected_backend = backend
+    if backend not in available_backends:
+        raise ImportError(
+            f"Requested backend '{backend}' not available. Available backends: {available_backends}"
+        )
+    selected_backend = backend
     
     logger.info(f"Selected debug backend: {selected_backend}")
     

--- a/tests/core/test_controller_observation_info.py
+++ b/tests/core/test_controller_observation_info.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import pytest
+
+def _stub_gui_deps():
+    PySide6 = types.ModuleType("PySide6")
+    sys.modules.setdefault("PySide6", PySide6)
+    sys.modules.setdefault("PySide6.QtWidgets", types.ModuleType("PySide6.QtWidgets"))
+    sys.modules.setdefault("PySide6.QtCore", types.ModuleType("PySide6.QtCore"))
+    sys.modules.setdefault("PySide6.QtGui", types.ModuleType("PySide6.QtGui"))
+
+
+def test_missing_num_agents_raises():
+    _stub_gui_deps()
+    from plume_nav_sim.core.controllers import BaseController
+    controller = BaseController()
+    with pytest.raises(AttributeError):
+        controller.get_observation_space_info()
+
+
+def test_observation_info_present():
+    _stub_gui_deps()
+    from plume_nav_sim.core.controllers import BaseController, DirectOdorSensor
+
+    class ConcreteController(BaseController):
+        def __init__(self):
+            super().__init__(sensors=[DirectOdorSensor()])
+            self.num_agents = 1
+
+    controller = ConcreteController()
+    info = controller.get_observation_space_info()
+    assert info["num_agents"] == 1
+    assert info["sensors"] == ["DirectOdorSensor"]

--- a/tests/visualization/test_debug_visualizer_backends.py
+++ b/tests/visualization/test_debug_visualizer_backends.py
@@ -90,3 +90,13 @@ def test_console_backend_removed(monkeypatch):
 
     with pytest.raises(ImportError):
         vis.create_debug_visualizer(backend="console")
+
+def test_auto_backend_disallowed(monkeypatch):
+    _stub_visualization_dependencies(monkeypatch)
+    path = Path("src/plume_nav_sim/utils/visualization.py")
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.utils.visualization", path)
+    vis = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(vis)
+
+    with pytest.raises(ImportError):
+        vis.create_debug_visualizer(backend="auto")


### PR DESCRIPTION
## Summary
- remove attribute fallbacks in `BaseController.get_observation_space_info`
- drop automatic backend fallback in `create_debug_visualizer`
- add tests covering observation info and visualizer backend selection

## Testing
- `PLUME_NAV_SIM_SKIP_INSTALL_CHECK=1 pytest tests/core/test_controller_observation_info.py tests/visualization/test_debug_visualizer_backends.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf168da0648320a9cc4f67b72251e4