### PR TITLE
fix: surface auto-discovery import failures

### DIFF
--- a/src/plume_nav_sim/models/__init__.py
+++ b/src/plume_nav_sim/models/__init__.py
@@ -824,8 +824,11 @@ def auto_discover_models() -> None:
                                 performance_characteristics={'auto_discovered': True}
                             )
                             
-            except ImportError:
-                pass  # Skip modules that can't be imported
+            except ImportError as e:
+                logger.exception(
+                    "Failed to import plume model module %s", module_name
+                )
+                raise
     
     # Try to auto-discover wind fields
     wind_path = models_package_path / 'wind'
@@ -852,8 +855,11 @@ def auto_discover_models() -> None:
                                 performance_characteristics={'auto_discovered': True}
                             )
                             
-            except ImportError:
-                pass
+            except ImportError as e:
+                logger.exception(
+                    "Failed to import wind field module %s", module_name
+                )
+                raise
 
 
 # Initialize the package by attempting auto-discovery

--- a/tests/models/test_auto_discover_import_error.py
+++ b/tests/models/test_auto_discover_import_error.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("PLUME_NAV_SIM_SKIP_INSTALL_CHECK", "1")
+
+import plume_nav_sim.models as models
+
+
+def test_auto_discover_models_raises_on_failed_import(monkeypatch):
+    """auto_discover_models should raise when a module import fails."""
+    sys.modules.pop('plume_nav_sim.models.plume.gaussian_plume', None)
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, package=None):
+        if name.endswith('.plume.gaussian_plume'):
+            raise ImportError("boom")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(models.importlib, 'import_module', fake_import_module)
+
+    with pytest.raises(ImportError):
+        models.auto_discover_models()


### PR DESCRIPTION
## Summary
- stop swallowing ImportError when auto-discovering plume and wind modules
- add regression test ensuring discovery raises on import failure

## Testing
- `pytest tests/models/test_auto_discover_import_error.py -q`
- `PLUME_NAV_SIM_SKIP_INSTALL_CHECK=1 pytest tests/models/test_models_package_imports.py -q` *(fails: ImportError: hydra missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf168da0648320a9cc4f67b72251e4