### PR TITLE
refactor: remove hydra stub from sensors module

### DIFF
--- a/src/plume_nav_sim/core/sensors/__init__.py
+++ b/src/plume_nav_sim/core/sensors/__init__.py
@@ -132,15 +132,9 @@ from plume_nav_sim.protocols.sensor import SensorProtocol
 PROTOCOLS_AVAILABLE = True
 
 # Hydra integration for configuration management
-try:
-    from hydra import utils as hydra_utils
-    from omegaconf import DictConfig, OmegaConf
-    HYDRA_AVAILABLE = True
-except ImportError:
-    hydra_utils = None
-    DictConfig = dict
-    OmegaConf = None
-    HYDRA_AVAILABLE = False
+from hydra import utils as hydra_utils
+from omegaconf import DictConfig, OmegaConf
+HYDRA_AVAILABLE = True
 
 # Performance monitoring integration
 try:

--- a/tests/sensors/test_base_sensor_dependencies.py
+++ b/tests/sensors/test_base_sensor_dependencies.py
@@ -13,6 +13,10 @@ def test_base_sensor_requires_dependencies():
     pkg_core_sensors = types.ModuleType('plume_nav_sim.core.sensors'); pkg_core_sensors.__path__ = []
     pkg_config = types.ModuleType('plume_nav_sim.config'); pkg_config.__path__ = []
     pkg_schemas = types.ModuleType('plume_nav_sim.config.schemas'); pkg_schemas.__path__ = []
+    pkg_protocols = types.ModuleType('plume_nav_sim.protocols'); pkg_protocols.__path__ = []
+    pkg_sensor_protocol = types.ModuleType('plume_nav_sim.protocols.sensor')
+    class SensorProtocol: ...
+    pkg_sensor_protocol.SensorProtocol = SensorProtocol
     class SensorConfig: ...
     pkg_schemas.SensorConfig = SensorConfig
 
@@ -22,6 +26,8 @@ def test_base_sensor_requires_dependencies():
         'plume_nav_sim.core.sensors': pkg_core_sensors,
         'plume_nav_sim.config': pkg_config,
         'plume_nav_sim.config.schemas': pkg_schemas,
+        'plume_nav_sim.protocols': pkg_protocols,
+        'plume_nav_sim.protocols.sensor': pkg_sensor_protocol,
     })
 
     spec = importlib.util.spec_from_file_location('plume_nav_sim.core.sensors.base_sensor', module_path)

--- a/tests/sensors/test_core_sensors_requires_hydra.py
+++ b/tests/sensors/test_core_sensors_requires_hydra.py
@@ -1,0 +1,52 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "src" / "plume_nav_sim" / "core" / "sensors" / "__init__.py"
+
+
+def test_sensors_import_requires_hydra(monkeypatch):
+    """Sensors module should error when Hydra is missing."""
+    pkg_plume = types.ModuleType("plume_nav_sim"); pkg_plume.__path__ = []
+    pkg_core = types.ModuleType("plume_nav_sim.core"); pkg_core.__path__ = []
+    sensors_pkg = types.ModuleType("plume_nav_sim.core.sensors"); sensors_pkg.__path__ = []
+    protocols_pkg = types.ModuleType("plume_nav_sim.protocols"); protocols_pkg.__path__ = []
+    sensor_protocol_pkg = types.ModuleType("plume_nav_sim.protocols.sensor")
+    class SensorProtocol: ...
+    sensor_protocol_pkg.SensorProtocol = SensorProtocol
+
+    sys.modules.update({
+        "plume_nav_sim": pkg_plume,
+        "plume_nav_sim.core": pkg_core,
+        "plume_nav_sim.core.sensors": sensors_pkg,
+        "plume_nav_sim.protocols": protocols_pkg,
+        "plume_nav_sim.protocols.sensor": sensor_protocol_pkg,
+    })
+
+    for name in ["base_sensor", "binary_sensor", "concentration_sensor", "gradient_sensor", "historical_sensor"]:
+        mod = types.ModuleType(f"plume_nav_sim.core.sensors.{name}")
+        cls_name = "".join(part.capitalize() for part in name.split("_"))
+        setattr(mod, cls_name, type(cls_name, (), {}))
+        sys.modules[f"plume_nav_sim.core.sensors.{name}"] = mod
+
+    for mod in list(sys.modules):
+        if mod.startswith("hydra") or mod.startswith("omegaconf"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    real_find_spec = importlib.machinery.PathFinder.find_spec
+
+    def fake_find_spec(fullname, path=None, target=None):
+        if fullname.startswith("hydra") or fullname.startswith("omegaconf"):
+            return None
+        return real_find_spec(fullname, path, target)
+
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", fake_find_spec)
+
+    spec = importlib.util.spec_from_file_location("plume_nav_sim.core.sensors", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with pytest.raises(ImportError):
+        spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- remove Hydra fallback from `core.sensors` so missing dependency raises immediately
- add regression test ensuring `plume_nav_sim.core.sensors` requires Hydra
- adjust base sensor dependency test to stub protocols

## Testing
- `pytest tests/sensors/test_core_sensors_requires_hydra.py -q`
- `pytest tests/sensors/test_base_sensor_dependencies.py -q`
- `pytest tests/sensors -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf43dcf2508320a647bdec0f7ac733