### PR TITLE
refactor: remove stubs and fallbacks

### DIFF
--- a/src/plume_nav_sim/core/controllers.py
+++ b/src/plume_nav_sim/core/controllers.py
@@ -631,19 +631,24 @@ class BaseController:
         )
 
     def get_observation_space_info(self) -> Dict[str, Any]:
-        """Return basic observation space metadata.
+        """Raise ``NotImplementedError`` for undefined observation metadata.
 
-        This stub provides minimal information required by tests and can be
-        extended by subclasses for richer observation descriptions.
+        BaseController no longer provides a stub implementation. Subclasses must
+        explicitly implement this method to expose their observation space
+        structure. Failing fast avoids silent assumptions about observation
+        semantics and surfaces incomplete implementations early.
 
-        Returns:
-            Dict[str, Any]: Dictionary with observation space details.
+        Raises:
+            NotImplementedError: Always raised to require subclass override.
         """
-        info = {
-            "num_agents": getattr(self, "num_agents", 0),
-            "sensors": [type(s).__name__ for s in getattr(self, "_sensors", [])],
-        }
-        return info
+        if self._logger:
+            self._logger.error(
+                "get_observation_space_info not implemented for %s",
+                self.__class__.__name__,
+            )
+        raise NotImplementedError(
+            "Subclasses must implement get_observation_space_info"
+        )
     
     def get_performance_metrics(self) -> Dict[str, Any]:
         """

--- a/src/plume_nav_sim/recording/backends/sqlite.py
+++ b/src/plume_nav_sim/recording/backends/sqlite.py
@@ -1039,8 +1039,7 @@ class SQLiteRecorder(BaseRecorder):
         Custom JSON serializer for numpy arrays and other non-serializable objects.
         
         Handles serialization of complex data types commonly used in simulation data
-        including numpy arrays, complex numbers, and custom objects. Provides fallback
-        string representation for unsupported types.
+        including numpy arrays, complex numbers, and custom objects.
         
         Args:
             obj: Object to serialize
@@ -1061,7 +1060,12 @@ class SQLiteRecorder(BaseRecorder):
         elif hasattr(obj, '__dict__'):
             return obj.__dict__
         else:
-            return str(obj)
+            logger.error(
+                "Unsupported object type for JSON serialization", obj_type=type(obj).__name__
+            )
+            raise TypeError(
+                f"Object of type {type(obj).__name__} is not JSON serializable"
+            )
     
     def get_performance_metrics(self) -> Dict[str, Any]:
         """

--- a/tests/controllers/test_controller_observation_space_info.py
+++ b/tests/controllers/test_controller_observation_space_info.py
@@ -1,0 +1,81 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def load_controllers_module():
+    module_path = Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'core' / 'controllers.py'
+
+    pkg_plume = types.ModuleType('plume_nav_sim'); pkg_plume.__path__ = []
+    pkg_core = types.ModuleType('plume_nav_sim.core'); pkg_core.__path__ = []
+    pkg_config = types.ModuleType('plume_nav_sim.config'); pkg_config.__path__ = []
+    pkg_schemas = types.ModuleType('plume_nav_sim.config.schemas'); pkg_schemas.__path__ = []
+    class NavigatorConfig: ...
+    class SingleAgentConfig: ...
+    class MultiAgentConfig: ...
+    pkg_schemas.NavigatorConfig = NavigatorConfig
+    pkg_schemas.SingleAgentConfig = SingleAgentConfig
+    pkg_schemas.MultiAgentConfig = MultiAgentConfig
+
+    pkg_utils = types.ModuleType('plume_nav_sim.utils'); pkg_utils.__path__ = []
+    pkg_frame_cache = types.ModuleType('plume_nav_sim.utils.frame_cache'); pkg_frame_cache.__path__ = []
+    class FrameCache: ...
+    class CacheMode: ...
+    pkg_frame_cache.FrameCache = FrameCache
+    pkg_frame_cache.CacheMode = CacheMode
+
+    pkg_envs = types.ModuleType('plume_nav_sim.envs'); pkg_envs.__path__ = []
+    pkg_envs_spaces = types.ModuleType('plume_nav_sim.envs.spaces'); pkg_envs_spaces.__path__ = []
+    class SpacesFactory: ...
+    pkg_envs_spaces.SpacesFactory = SpacesFactory
+
+    pkg_protocols = types.ModuleType('plume_nav_sim.protocols'); pkg_protocols.__path__ = []
+    pkg_protocols_nav = types.ModuleType('plume_nav_sim.protocols.navigator')
+    class NavigatorProtocol: ...
+    pkg_protocols_nav.NavigatorProtocol = NavigatorProtocol
+    pkg_protocols_sensor = types.ModuleType('plume_nav_sim.protocols.sensor')
+    class SensorProtocol: ...
+    pkg_protocols_sensor.SensorProtocol = SensorProtocol
+
+    pkg_core_protocols = types.ModuleType('plume_nav_sim.core.protocols')
+    class BoundaryPolicyProtocol: ...
+    class SourceProtocol: ...
+    pkg_core_protocols.BoundaryPolicyProtocol = BoundaryPolicyProtocol
+    pkg_core_protocols.SourceProtocol = SourceProtocol
+
+    pkg_core_boundaries = types.ModuleType('plume_nav_sim.core.boundaries')
+    def create_boundary_policy(*args, **kwargs): ...
+    pkg_core_boundaries.create_boundary_policy = create_boundary_policy
+
+    sys.modules.update({
+        'plume_nav_sim': pkg_plume,
+        'plume_nav_sim.core': pkg_core,
+        'plume_nav_sim.config': pkg_config,
+        'plume_nav_sim.config.schemas': pkg_schemas,
+        'plume_nav_sim.utils': pkg_utils,
+        'plume_nav_sim.utils.frame_cache': pkg_frame_cache,
+        'plume_nav_sim.envs': pkg_envs,
+        'plume_nav_sim.envs.spaces': pkg_envs_spaces,
+        'plume_nav_sim.protocols': pkg_protocols,
+        'plume_nav_sim.protocols.navigator': pkg_protocols_nav,
+        'plume_nav_sim.protocols.sensor': pkg_protocols_sensor,
+        'plume_nav_sim.core.protocols': pkg_core_protocols,
+        'plume_nav_sim.core.boundaries': pkg_core_boundaries,
+    })
+
+    spec = importlib.util.spec_from_file_location('plume_nav_sim.core.controllers', module_path)
+    controllers = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = controllers
+    spec.loader.exec_module(controllers)
+    return controllers
+
+
+def test_base_controller_observation_space_info_not_implemented():
+    controllers = load_controllers_module()
+    BaseController = controllers.BaseController
+    controller = BaseController(enable_logging=False)
+    with pytest.raises(NotImplementedError):
+        controller.get_observation_space_info()

--- a/tests/recording/test_sqlite_serializer.py
+++ b/tests/recording/test_sqlite_serializer.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / 'src' / 'plume_nav_sim' / 'recording' / 'backends' / 'sqlite.py'
+MODULE_NAME = 'plume_nav_sim.recording.backends.sqlite_test'
+
+
+@dataclass
+class RecorderConfig:
+    backend: str
+    output_dir: str
+    buffer_size: int = 100
+    compression: str = 'none'
+    async_io: bool = False
+    database_path: str = 'recording.db'
+
+    def __post_init__(self):
+        pass
+
+
+class BaseRecorder:
+    def __init__(self, config):
+        self.config = config
+        self.run_id = 'run'
+        self.base_dir = config.output_dir
+
+    def start_recording(self, episode_id):
+        self.base_dir = self.config.output_dir
+
+    def record_step(self, data, step_number, episode_id):
+        pass
+
+    def stop_recording(self):
+        pass
+
+
+def load_module():
+    pkg = types.ModuleType('plume_nav_sim')
+    pkg.__path__ = []
+    recording_pkg = types.ModuleType('plume_nav_sim.recording')
+    recording_pkg.BaseRecorder = BaseRecorder
+    recording_pkg.RecorderConfig = RecorderConfig
+    sys.modules['plume_nav_sim'] = pkg
+    sys.modules['plume_nav_sim.recording'] = recording_pkg
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sqlite_serializer_unsupported_type(tmp_path):
+    module = load_module()
+    SQLiteRecorder = module.SQLiteRecorder
+    SQLiteConfig = module.SQLiteConfig
+    config = SQLiteConfig(backend='sqlite', output_dir=str(tmp_path), database_path=str(tmp_path / 'test.db'))
+    recorder = SQLiteRecorder(config)
+
+    with pytest.raises(TypeError):
+        recorder._json_serializer(object())


### PR DESCRIPTION
## Summary
- remove stubbed observation metadata method from BaseController
- raise on unsupported object serialization in SQLite recorder
- add tests for controller metadata and serializer errors

## Testing
- `pytest tests/controllers/test_controller_observation_space_info.py::test_base_controller_observation_space_info_not_implemented -q`
- `pytest tests/recording/test_sqlite_serializer.py::test_sqlite_serializer_unsupported_type -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf7c9cb4e88320b89c930cc5be8071