### PR TITLE
feat: allow running from source without installation

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<USAGE
+Usage: $(basename "$0") [--dev]
+  --dev   Install development dependencies
+USAGE
+}
+
+DEV=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dev)
+      DEV=1
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown option: $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+PY_BIN=$(command -v python || true)
+PIP_BIN=$(command -v pip || true)
+
+echo "[INFO] Using python: ${PY_BIN:-missing}"
+echo "[INFO] Using pip: ${PIP_BIN:-missing}"
+
+if [[ -z "$PY_BIN" ]]; then
+  echo "[ERROR] python not found" >&2
+  exit 1
+fi
+if [[ -z "$PIP_BIN" ]]; then
+  echo "[ERROR] pip not found" >&2
+  exit 1
+fi
+
+REQ=requirements.txt
+if [[ $DEV -eq 1 ]]; then
+  REQ=requirements-dev.txt
+fi
+
+if [[ ! -f "$REQ" ]]; then
+  echo "[ERROR] $REQ not found" >&2
+  exit 1
+fi
+
+echo "[INFO] Installing dependencies from $REQ"
+$PIP_BIN install -r "$REQ"
+
+echo "[INFO] Installing plume_nav_sim in editable mode"
+$PIP_BIN install -e .
+
+echo "[INFO] Environment ready"
+$PY_BIN --version
+$PIP_BIN --version

--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -48,11 +48,11 @@ try:  # pragma: no cover - exercised in tests via monkeypatch
     distribution("plume_nav_sim")
 except PackageNotFoundError as e:  # pragma: no cover - executed when not installed
     msg = (
-        "plume_nav_sim must be installed before use. "
-        "Run 'pip install -e .' or './setup_env.sh --dev'."
+        "plume_nav_sim is running from source without being installed. "
+        "Run 'pip install -e .' or './setup_env.sh --dev' for full functionality."
     )
-    logger.error(msg)
-    raise ImportError(msg) from e
+    warnings.warn(msg)
+    logger.warning(msg)
 
 # =============================================================================
 # LEGACY GYM DETECTION AND DEPRECATION WARNING SYSTEM

--- a/tests/test_import_requires_installation.py
+++ b/tests/test_import_requires_installation.py
@@ -1,11 +1,12 @@
+"""Validate import behaviour when package metadata is missing."""
+
 import importlib.metadata
 import sys
 
 import pytest
 
 
-def test_import_requires_installation(monkeypatch):
-    """Importing without installed distribution should fail."""
+def test_import_warns_when_not_installed(monkeypatch):
     from importlib.metadata import PackageNotFoundError
 
     def fake_distribution(name: str):
@@ -14,5 +15,5 @@ def test_import_requires_installation(monkeypatch):
     monkeypatch.setattr(importlib.metadata, "distribution", fake_distribution)
     sys.modules.pop("plume_nav_sim", None)
 
-    with pytest.raises(ImportError, match="pip install -e"):
+    with pytest.warns(UserWarning, match="pip install -e"):
         __import__("plume_nav_sim")

--- a/tests/test_import_source.py
+++ b/tests/test_import_source.py
@@ -1,0 +1,9 @@
+import importlib
+import sys
+import pytest
+
+
+def test_import_from_source_succeeds():
+    sys.modules.pop('plume_nav_sim', None)
+    module = importlib.import_module('plume_nav_sim')
+    assert hasattr(module, '__version__')

--- a/tests/test_setup_env_script.py
+++ b/tests/test_setup_env_script.py
@@ -1,0 +1,10 @@
+import subprocess
+import pathlib
+
+
+def test_setup_env_help_shows_dev_flag():
+    script = pathlib.Path('setup_env.sh')
+    assert script.exists(), 'setup_env.sh script missing'
+    result = subprocess.run(['bash', str(script), '--help'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert '--dev' in result.stdout, 'Expected --dev flag documented in help output'


### PR DESCRIPTION
## Summary
- avoid ImportError when `plume_nav_sim` is used from source without installation
- add regression test covering import from source
- update import test to expect warning when metadata missing
- provide `setup_env.sh` helper script with `--dev` flag and verbose checks
- add test ensuring setup script documents `--dev` flag

## Testing
- `pytest tests/test_setup_env_script.py -q`
- `pytest tests/test_import_source.py tests/test_import_requires_installation.py -q`
- `pytest tests/cli/test_cli_main.py -q` *(fails: Database layer and `numba` optional dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68befdb28e6c832085cb75ac09192260