### PR TITLE
docs: clarify dev installation instructions

### DIFF
--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -59,13 +59,21 @@ pip install plume_nav_sim[all]
 ```
 
 ### Development Installation
-To work from a source checkout, install the package in editable mode to ensure
-all dependencies are available:
+On Unix-like systems (Linux or macOS), use the provided setup script for a
+fully configured development environment:
 
 ```bash
-pip install -e .
-# or
 ./setup_env.sh --dev
+```
+
+The script emits verbose logging for each step and fails fast on any error.
+It does not support Windows shells.
+
+If the script cannot run, install the package in editable mode with the
+development extras:
+
+```bash
+pip install -e .[dev]
 ```
 
 ### Optional Dependency Groups

--- a/tests/test_docs_dev_installation.py
+++ b/tests/test_docs_dev_installation.py
@@ -1,0 +1,9 @@
+import pathlib
+
+def test_dev_installation_section_mentions_script_and_alternative():
+    text = pathlib.Path("docs/api_reference/index.md").read_text()
+    assert "Unix-like systems" in text
+    assert "./setup_env.sh --dev" in text
+    assert "pip install -e .[dev]" in text
+    assert "verbose logging" in text
+    assert "fails fast" in text


### PR DESCRIPTION
## Summary
- clarify development installation steps
- highlight `setup_env.sh --dev` fail-fast logging on Unix
- add test ensuring docs mention script and editable install fallback

## Testing
- `PLUMENAV_SKIP_INSTALL=1 ./setup_env.sh --dev`
- `pytest tests/test_docs_dev_installation.py -q`
- `pytest -q` *(fails: AttributeError: '_DummyDistribution' object has no attribute 'locate_file')*

------
https://chatgpt.com/codex/tasks/task_e_68c026ed9b708320a781c58fcd5c068f