### PR TITLE
fix: clarify install instructions in import error

### DIFF
--- a/src/plume_nav_sim/__init__.py
+++ b/src/plume_nav_sim/__init__.py
@@ -51,7 +51,7 @@ if os.environ.get("PLUME_NAV_SIM_SKIP_INSTALL_CHECK") != "1":
     except PackageNotFoundError as e:  # pragma: no cover - executed when not installed
         msg = (
             "plume_nav_sim must be installed before use. "
-            "Run 'pip install -e .' or './setup_env.sh --dev'."
+            "Run './setup_env.sh --dev' or 'pip install -e .' first."
         )
         logger.error(msg)
         raise ImportError(msg) from e

--- a/tests/test_import_requires_installation.py
+++ b/tests/test_import_requires_installation.py
@@ -16,3 +16,25 @@ def test_import_requires_installation(monkeypatch):
 
     with pytest.raises(ImportError, match="pip install -e"):
         __import__("plume_nav_sim")
+
+
+def test_import_requires_installation_logs(monkeypatch):
+    """Importing without installation logs clear instructions."""
+    from importlib.metadata import PackageNotFoundError
+    from loguru import logger
+
+    def fake_distribution(name: str):
+        raise PackageNotFoundError
+
+    logs = []
+
+    monkeypatch.setattr(importlib.metadata, "distribution", fake_distribution)
+    monkeypatch.setattr(logger, "error", lambda msg: logs.append(msg))
+    sys.modules.pop("plume_nav_sim", None)
+
+    with pytest.raises(
+        ImportError,
+        match=r"setup_env\.sh --dev' or 'pip install -e \.",
+    ):
+        __import__("plume_nav_sim")
+    assert any("setup_env.sh --dev" in m for m in logs)


### PR DESCRIPTION
## Summary
- clarify import error to mention `./setup_env.sh --dev` and `pip install -e .`
- log installation error consistently
- test install check logs clear instructions

## Testing
- `pytest tests/test_import_requires_installation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02d1682248320b066586e073d45dd