### PR TITLE
feat: restore integration and performance helpers

### DIFF
--- a/src/backend/benchmarks/__init__.py
+++ b/src/backend/benchmarks/__init__.py
@@ -28,7 +28,7 @@ from .environment_performance import (
 )
 
 # Internal imports - Logging infrastructure for benchmark orchestration and progress tracking
-from ..plume_nav_sim.utils.logging import get_component_logger  # Component-specific logger factory for benchmark orchestration logging
+from plume_nav_sim.utils.logging import get_component_logger  # Component-specific logger factory for benchmark orchestration logging
 
 # Graceful handling of missing benchmark modules with placeholder implementations
 # This ensures the package works even when some benchmark files don't exist yet
@@ -125,7 +125,7 @@ except ImportError:
 
 # Graceful handling of missing configuration module with fallback defaults
 try:
-    from ..config.default_config import get_complete_default_config
+    from config.default_config import get_complete_default_config
 except ImportError:
     # Fallback implementation for missing default configuration
     def get_complete_default_config():

--- a/src/backend/plume_nav_sim/envs/plume_search_env.py
+++ b/src/backend/plume_nav_sim/envs/plume_search_env.py
@@ -174,7 +174,13 @@ class PlumeSearchEnv:
         max_steps: Optional[int] = None,
         goal_radius: Optional[float] = None,
         plume_params: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> None:
+        if kwargs:
+            logger.debug(
+                "Ignoring unsupported configuration fields for PlumeSearchEnv: %s",
+                sorted(kwargs.keys()),
+            )
         self.grid_size = _validate_grid_size(grid_size)
         self.source_location = _validate_source_location(source_location, self.grid_size)
 

--- a/src/backend/plume_nav_sim/envs/plume_search_env.py
+++ b/src/backend/plume_nav_sim/envs/plume_search_env.py
@@ -1,98 +1,400 @@
-"""Fallback stubs for the plume search environment in minimal builds.
+"""Lightweight plume search environment used in the trimmed kata build.
 
-The original project exposes a richly featured :mod:`plume_nav_sim.envs.plume_search_env`
-module that provides the :class:`PlumeSearchEnv` Gymnasium environment alongside
-factory and validation helpers.  The educational copy of the repository that backs
-this kata does not bundle the full environment implementation, yet a large portion
-of the codebase (including pytest fixtures) still imports the public symbols.  The
-absence of the module causes import-time failures that mask the behaviour we want to
-exercise in the refactor under test.
+The original project ships a considerably more sophisticated Gymnasium
+environment.  Shipping the full simulator is unnecessary for the unit tests in
+this kata, yet a realistic surface is still valuable: the edge-case and
+performance suites expect an environment that can reset, step through episodes,
+render deterministic RGB arrays, and perform basic validation.  This module
+implements a compact but fully functional replacement that intentionally focuses
+on determinism, clarity, and aggressive input validation so the surrounding
+tests can execute meaningful scenarios.
 
-To keep the public API stable while avoiding the heavy runtime dependency, this file
-provides lightweight stand-ins for the canonical objects.  They intentionally offer
-only the minimal surface required for type annotations and attribute access.  Any
-attempt to *use* the environment—resetting, stepping, or rendering—raises a clear
-:class:`ComponentError` so callers understand that the concrete implementation is not
-available in this trimmed environment.
+The implementation favours explicit logging and predictable behaviour over raw
+feature parity.  Each public method guards against misuse, raising the
+exceptions defined in :mod:`plume_nav_sim.utils.exceptions` so callers receive
+actionable feedback instead of silent fallbacks.  The environment keeps enough
+state to service the tests while remaining easy to reason about for students.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+import logging
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
 
-from ..utils.exceptions import ComponentError
+import numpy as np
 
-__all__ = [
-    "PlumeSearchEnv",
-    "create_plume_search_env",
-    "validate_plume_search_config",
-]
+from ..core.constants import (
+    ACTION_SPACE_SIZE,
+    AGENT_MARKER_COLOR,
+    DEFAULT_GOAL_RADIUS,
+    DEFAULT_GRID_SIZE,
+    DEFAULT_MAX_STEPS,
+    DEFAULT_PLUME_SIGMA,
+    DEFAULT_SOURCE_LOCATION,
+    MAX_PLUME_SIGMA,
+    MIN_PLUME_SIGMA,
+    PIXEL_VALUE_MAX,
+    PIXEL_VALUE_MIN,
+    RGB_DTYPE,
+    SEED_MAX_VALUE,
+    SEED_MIN_VALUE,
+)
+from ..core.types import Action
+from ..utils.exceptions import ConfigurationError, RenderingError, StateError, ValidationError
+
+__all__ = ["PlumeSearchEnv", "create_plume_search_env", "validate_plume_search_config"]
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_grid_size(grid_size: Optional[Tuple[int, int]]) -> Tuple[int, int]:
+    """Normalise and validate the incoming grid dimensions."""
+
+    if grid_size is None:
+        return DEFAULT_GRID_SIZE
+
+    try:
+        width = int(grid_size[0])
+        height = int(grid_size[1])
+    except (TypeError, ValueError, IndexError) as exc:  # pragma: no cover - defensive
+        raise ConfigurationError("grid_size must be a length-2 iterable of integers") from exc
+
+    if width <= 0 or height <= 0:
+        raise ConfigurationError("grid_size values must be positive integers")
+
+    return width, height
+
+
+def _validate_source_location(source: Optional[Tuple[int, int]], grid: Tuple[int, int]) -> Tuple[int, int]:
+    """Validate that the source lies within the configured grid bounds."""
+
+    if source is None:
+        # Default to the centre of the configured grid so small test grids remain valid.
+        width, height = grid
+        source = (width // 2, height // 2)
+
+    try:
+        x = int(source[0])
+        y = int(source[1])
+    except (TypeError, ValueError, IndexError) as exc:  # pragma: no cover - defensive
+        raise ConfigurationError("source_location must be a length-2 iterable of integers") from exc
+
+    width, height = grid
+    if not (0 <= x < width and 0 <= y < height):
+        raise ConfigurationError(
+            f"source_location {source!r} must be within grid bounds 0..{width - 1}, 0..{height - 1}"
+        )
+
+    return x, y
+
+
+def _validate_sigma(value: Optional[float]) -> float:
+    """Validate plume spread (sigma) parameters."""
+
+    if value is None:
+        return DEFAULT_PLUME_SIGMA
+
+    try:
+        sigma = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ConfigurationError("plume_params.sigma must be numeric") from exc
+
+    if math.isnan(sigma) or math.isinf(sigma) or sigma <= 0:
+        raise ConfigurationError("plume_params.sigma must be a positive finite number")
+
+    if not (MIN_PLUME_SIGMA <= sigma <= MAX_PLUME_SIGMA):
+        raise ConfigurationError(
+            f"plume_params.sigma must be within [{MIN_PLUME_SIGMA}, {MAX_PLUME_SIGMA}]"
+        )
+
+    return sigma
+
+
+def _resolve_seed(seed: Optional[Any]) -> Optional[int]:
+    """Coerce seeds to integers while preserving deterministic behaviour."""
+
+    if seed is None:
+        return None
+
+    if isinstance(seed, (np.integer, int)):
+        seed_value = int(seed)
+    elif isinstance(seed, float) and seed.is_integer():
+        seed_value = int(seed)
+    else:
+        raise ValidationError("Seed must be an integer, float integral value, or None", parameter_name="seed")
+
+    if not (SEED_MIN_VALUE <= seed_value <= SEED_MAX_VALUE):
+        raise ValidationError("Seed is outside the supported range", parameter_name="seed")
+
+    return seed_value
+
+
+class _DiscreteActionSpace:
+    """Minimal discrete action space exposing the API the tests exercise."""
+
+    def __init__(self, rng: np.random.Generator) -> None:
+        self.n = ACTION_SPACE_SIZE
+        self._rng = rng
+
+    def sample(self) -> int:
+        value = int(self._rng.integers(0, self.n))
+        logger.debug("Sampled action value %s from discrete space", value)
+        return value
+
+    def contains(self, item: Any) -> bool:
+        try:
+            value = int(item)
+        except (TypeError, ValueError):
+            return False
+        return 0 <= value < self.n
+
+
+@dataclass
+class _ObservationSpace:
+    """Very small observation-space stub used by the test-suite assertions."""
+
+    shape: Tuple[int, int, int]
+    dtype: Any = np.float32
 
 
 class PlumeSearchEnv:
-    """Minimal stub of the real PlumeSearchEnv implementation.
+    """Deterministic grid environment with Gaussian concentration field."""
 
-    The class intentionally accepts any initialisation arguments so existing import
-    sites continue to work.  Operational methods raise :class:`ComponentError` to
-    communicate that the full simulator is not part of this pared-down build.
-    """
+    metadata: Dict[str, Any] = {"render_modes": ["rgb_array", "human"]}
 
-    #: Metadata attribute expected by Gymnasium environments.
-    metadata: Dict[str, Any] = {"render_modes": ["human", "rgb_array"]}
-    #: Action space placeholder exposed for type compatibility.
-    action_space: Any = None
-    #: Observation space placeholder exposed for type compatibility.
-    observation_space: Any = None
+    def __init__(
+        self,
+        *,
+        grid_size: Optional[Tuple[int, int]] = None,
+        source_location: Optional[Tuple[int, int]] = None,
+        max_steps: Optional[int] = None,
+        goal_radius: Optional[float] = None,
+        plume_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.grid_size = _validate_grid_size(grid_size)
+        self.source_location = _validate_source_location(source_location, self.grid_size)
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._init_args = args
-        self._init_kwargs = kwargs
+        if max_steps is None:
+            max_steps = DEFAULT_MAX_STEPS
+        if not isinstance(max_steps, int) or max_steps <= 0:
+            raise ConfigurationError("max_steps must be a positive integer")
+        self.max_steps = int(max_steps)
 
-    def reset(self, *args: Any, **kwargs: Any) -> Tuple[Any, Dict[str, Any]]:
-        """Resetting the stub environment is unsupported."""
+        if goal_radius is None:
+            goal_radius = DEFAULT_GOAL_RADIUS
+        if not isinstance(goal_radius, (int, float)) or goal_radius < 0:
+            raise ConfigurationError("goal_radius must be a non-negative number")
+        self.goal_radius = float(goal_radius)
 
-        raise ComponentError(
-            "The PlumeSearchEnv simulation is unavailable in this test fixture.",
-            component_name="PlumeSearchEnv",
-            operation_name="reset",
+        sigma_input = None
+        if plume_params:
+            sigma_input = plume_params.get("sigma")
+        self._sigma = _validate_sigma(sigma_input)
+
+        self._rng_seed: Optional[int] = None
+        self._rng = np.random.default_rng()
+        self.action_space = _DiscreteActionSpace(self._rng)
+        self.observation_space = _ObservationSpace(shape=(self.grid_size[0], self.grid_size[1], 1))
+
+        self._step_count = 0
+        self._episode_active = False
+        self._closed = False
+        self._agent_position = self.source_location
+        self._lock = threading.RLock()
+
+        logger.info(
+            "Initialised PlumeSearchEnv grid=%s source=%s max_steps=%s goal_radius=%s sigma=%.3f",
+            self.grid_size,
+            self.source_location,
+            self.max_steps,
+            self.goal_radius,
+            self._sigma,
         )
 
-    def step(self, *args: Any, **kwargs: Any) -> Tuple[Any, float, bool, bool, Dict[str, Any]]:
-        """Advancing the stub environment is unsupported."""
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _ensure_active(self) -> None:
+        if self._closed:
+            raise StateError("Environment has been closed", current_state="closed", component_name="env")
 
-        raise ComponentError(
-            "The PlumeSearchEnv simulation is unavailable in this test fixture.",
-            component_name="PlumeSearchEnv",
-            operation_name="step",
-        )
+    def _update_rng(self, seed: Optional[int]) -> None:
+        if seed is None:
+            seed = int(time.time_ns() % (SEED_MAX_VALUE + 1))
+        self._rng_seed = seed
+        self._rng = np.random.default_rng(seed)
+        self.action_space = _DiscreteActionSpace(self._rng)
+        logger.debug("Reset RNG with seed %s", seed)
 
-    def render(self, *args: Any, **kwargs: Any) -> Any:
-        """Rendering is not implemented in the stub environment."""
+    def _random_agent_position(self) -> Tuple[int, int]:
+        width, height = self.grid_size
+        x = int(self._rng.integers(0, width))
+        y = int(self._rng.integers(0, height))
+        return x, y
 
-        raise ComponentError(
-            "The PlumeSearchEnv renderer is not bundled in this pared-down build.",
-            component_name="PlumeSearchEnv",
-            operation_name="render",
-        )
+    def _compute_distance(self, position: Tuple[int, int]) -> float:
+        sx, sy = self.source_location
+        px, py = position
+        return math.hypot(px - sx, py - sy)
+
+    def _compute_concentration(self, position: Tuple[int, int]) -> float:
+        distance = self._compute_distance(position)
+        exponent = -((distance ** 2) / (2 * (self._sigma ** 2)))
+        value = math.exp(exponent)
+        return max(0.0, min(1.0, value))
+
+    def _observation(self) -> np.ndarray:
+        concentration = self._compute_concentration(self._agent_position)
+        normalised_steps = self._step_count / max(1, self.max_steps)
+        distance = self._compute_distance(self._agent_position)
+        obs = np.array([concentration, normalised_steps, distance], dtype=np.float32)
+        return obs
+
+    def _info(self) -> Dict[str, Any]:
+        return {
+            "agent_xy": self._agent_position,
+            "plume_peak_xy": self.source_location,
+            "distance_to_source": self._compute_distance(self._agent_position),
+            "step_count": self._step_count,
+            "seed": self._rng_seed,
+        }
+
+    # ------------------------------------------------------------------
+    # Gymnasium-style API
+    def reset(self, *, seed: Optional[Any] = None, options: Optional[Dict[str, Any]] = None) -> Tuple[np.ndarray, Dict[str, Any]]:
+        with self._lock:
+            self._ensure_active()
+            resolved_seed = _resolve_seed(seed)
+            self._update_rng(resolved_seed)
+            self._step_count = 0
+            self._episode_active = True
+            self._agent_position = self._random_agent_position()
+            logger.debug("Environment reset with seed=%s position=%s", resolved_seed, self._agent_position)
+            return self._observation(), self._info()
+
+    def step(self, action: Any) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+        with self._lock:
+            self._ensure_active()
+            if not self._episode_active:
+                raise StateError("Environment must be reset before stepping", current_state="inactive", component_name="env")
+
+            try:
+                action_enum = Action(int(action))
+            except (ValueError, TypeError):
+                raise ValidationError("Action must be an integer in range [0, 3]", parameter_name="action")
+
+            dx, dy = action_enum.to_vector()
+            x, y = self._agent_position
+            width, height = self.grid_size
+            new_x = int(np.clip(x + dx, 0, width - 1))
+            new_y = int(np.clip(y + dy, 0, height - 1))
+            self._agent_position = (new_x, new_y)
+            self._step_count += 1
+
+            distance = self._compute_distance(self._agent_position)
+            reward = float(1.0 - min(distance, width + height) / (width + height))
+
+            terminated = distance <= self.goal_radius
+            truncated = self._step_count >= self.max_steps
+            if terminated or truncated:
+                self._episode_active = False
+
+            observation = self._observation()
+            info = self._info()
+            logger.debug(
+                "Step action=%s position=%s reward=%.3f terminated=%s truncated=%s",
+                action_enum.name,
+                self._agent_position,
+                reward,
+                terminated,
+                truncated,
+            )
+            return observation, reward, terminated, truncated, info
+
+    def render(self, mode: str = "human") -> Optional[np.ndarray]:
+        with self._lock:
+            self._ensure_active()
+            mode = mode or "human"
+            if mode not in self.metadata["render_modes"]:
+                raise RenderingError(f"Unsupported render mode: {mode}", render_mode=mode)
+
+            if mode == "rgb_array":
+                return self._render_rgb_array()
+
+            try:
+                import matplotlib.pyplot as plt  # type: ignore[import-not-found]
+
+                field = self._render_rgb_array()
+                fig, ax = plt.subplots(figsize=(6, 6))
+                ax.imshow(field)
+                ax.set_title("Plume Navigation Environment")
+                ax.axis("off")
+                plt.close(fig)
+                return None
+            except Exception as exc:  # pragma: no cover - exercised via tests
+                logger.warning("Human rendering failed, falling back to rgb_array: %s", exc)
+                try:
+                    return self._render_rgb_array()
+                except Exception as fallback_exc:  # pragma: no cover - defensive
+                    raise RenderingError(
+                        "Rendering failed even after attempting rgb_array fallback",
+                        render_mode=mode,
+                        underlying_error=fallback_exc,
+                    ) from exc
 
     def close(self) -> None:
-        """Closing the stub is a no-op."""
+        with self._lock:
+            self._episode_active = False
+            self._closed = True
+            logger.info("Closed PlumeSearchEnv")
 
-        return None
+    # ------------------------------------------------------------------
+    # Additional helpers exercised by the tests
+    def validate_environment_integrity(self) -> bool:
+        with self._lock:
+            healthy = not self._closed and self.grid_size[0] > 0 and self.grid_size[1] > 0
+            healthy = healthy and isinstance(self._rng_seed, (int, type(None)))
+            healthy = healthy and isinstance(self._agent_position, tuple)
+            return healthy
+
+    # ------------------------------------------------------------------
+    # Internal rendering helpers
+    def _render_rgb_array(self) -> np.ndarray:
+        width, height = self.grid_size
+        field = np.zeros((height, width, 3), dtype=RGB_DTYPE)
+
+        # Create a smooth gradient so tests can check determinism without storing huge fixtures
+        x_indices = np.linspace(0, 1, num=width, dtype=np.float32)
+        y_indices = np.linspace(0, 1, num=height, dtype=np.float32)
+        gradient = np.outer(y_indices, x_indices)
+        base_layer = (gradient * PIXEL_VALUE_MAX).astype(RGB_DTYPE)
+        field[:, :, 0] = base_layer
+        field[:, :, 1] = base_layer
+        field[:, :, 2] = base_layer
+
+        ax, ay = self._agent_position
+        sx, sy = self.source_location
+        field[ay, ax] = np.array(AGENT_MARKER_COLOR, dtype=RGB_DTYPE)
+        field[sy, sx] = np.array(AGENT_MARKER_COLOR, dtype=RGB_DTYPE)
+        return field
 
 
-def create_plume_search_env(*args: Any, **kwargs: Any) -> PlumeSearchEnv:
-    """Factory function mirroring the public API of the full package."""
+def create_plume_search_env(**kwargs: Any) -> PlumeSearchEnv:
+    """Factory mirroring the public API of the original project."""
 
-    return PlumeSearchEnv(*args, **kwargs)
+    return PlumeSearchEnv(**kwargs)
 
 
-def validate_plume_search_config(*args: Any, **kwargs: Any) -> Dict[str, Any]:
-    """Placeholder validation helper.
+def validate_plume_search_config(**kwargs: Any) -> Dict[str, Any]:
+    """Expose a helper used by the tests for sanity-checking parameters."""
 
-    The real implementation performs extensive configuration checks.  The stub keeps
-    the signature compatible and simply returns the collected parameters so callers
-    can inspect what would have been validated.
-    """
+    grid = _validate_grid_size(kwargs.get("grid_size"))
+    source = _validate_source_location(kwargs.get("source_location"), grid)
+    sigma = _validate_sigma(kwargs.get("plume_params", {}).get("sigma") if kwargs.get("plume_params") else None)
+    result = {"grid_size": grid, "source_location": source, "sigma": sigma}
+    logger.debug("Validated plume configuration: %s", result)
+    return result
 
-    return {"args": args, "kwargs": kwargs}

--- a/src/backend/tests/__init__.py
+++ b/src/backend/tests/__init__.py
@@ -36,7 +36,7 @@ try:  # pragma: no cover - import guard for optional fixtures
         # Context manager classes for resource management and performance tracking
         TestEnvironmentManager, PerformanceTracker
     )
-except Exception:  # pragma: no cover - exercised only in minimal kata builds
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised only in minimal kata builds
     def _missing_fixture(*_args: Any, **_kwargs: Any):  # type: ignore[override]
         pytest.skip(
             "Comprehensive environment fixtures are unavailable in the kata sandbox."
@@ -75,7 +75,7 @@ try:  # pragma: no cover - import guard for optional API compliance tests
         test_gymnasium_api_compliance,
         test_seeding_and_reproducibility
     )
-except Exception:  # pragma: no cover - exercised only in minimal kata builds
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised only in minimal kata builds
     TestEnvironmentAPI = None  # type: ignore[assignment]
 
     def test_environment_inheritance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
@@ -100,7 +100,8 @@ try:  # pragma: no cover - import guard for optional performance tests
         test_memory_usage_constraints,
         test_comprehensive_performance_suite
     )
-except Exception:  # pragma: no cover - exercised only in minimal kata builds
+except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover - exercised only in minimal kata builds
+    warnings.warn(f"Performance test suite could not be imported: {exc}")
     TestPerformanceValidation = None  # type: ignore[assignment]
 
     def test_environment_step_latency_performance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
@@ -122,17 +123,10 @@ try:  # pragma: no cover - import guard for optional integration tests
         test_cross_component_seeding,
         test_system_level_performance
     )
-except Exception:  # pragma: no cover - exercised only in minimal kata builds
-    TestEnvironmentIntegration = None  # type: ignore[assignment]
-
-    def test_complete_episode_workflow(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Integration tests are unavailable in this minimal environment.")
-
-    def test_cross_component_seeding(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Integration tests are unavailable in this minimal environment.")
-
-    def test_system_level_performance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Integration tests are unavailable in this minimal environment.")
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised only in minimal kata builds
+    raise ImportError(
+        "The integration test module is missing; add tests/test_integration.py to restore coverage."
+    ) from exc
 
 # Package metadata and version information
 __version__ = "0.0.1"  # Test package version for compatibility and version tracking

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -1,8 +1,31 @@
-"""Minimal pytest configuration for the kata environment."""
+"""Pytest fixtures that provide realistic stand-ins for the trimmed test suite."""
 
 from __future__ import annotations
 
+import contextlib
+import logging
+import threading
+import time
+import tracemalloc
+from collections.abc import MutableMapping, Iterator
+from dataclasses import dataclass, field
+from typing import Any, Dict, Generator, Optional
+
+import psutil
 import pytest
+
+from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
+
+logger = logging.getLogger(__name__)
+
+try:
+    import matplotlib  # noqa: F401  # Imported for capability detection only
+
+    matplotlib_available = True
+except Exception:  # pragma: no cover - matplotlib is optional in CI
+    matplotlib_available = False
+
+single_threaded_only = False
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -35,3 +58,296 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "Stub ini option for kata environment.",
         default="none",
     )
+
+
+@dataclass
+class PerformanceTracker(MutableMapping[str, Any]):
+    """Lightweight performance tracker used by the edge-case suite.
+
+    The historical fixture behaved like a dictionary in the performance tests, so this
+    implementation exposes a :class:`MutableMapping` interface while still providing
+    the richer helper methods needed by the edge-case scenarios. The mapping view is
+    backed by thread-safe storage so that tests can append timing samples or record
+    benchmark summaries without race conditions.
+    """
+
+    _session_name: Optional[str] = None
+    _start_time: Optional[float] = None
+    _step_durations: list[float] = field(default_factory=list)
+    _total_steps: int = 0
+    _lock: threading.RLock = field(default_factory=threading.RLock)
+    _process: psutil.Process = field(default_factory=psutil.Process)
+    _store: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        with self._lock:
+            baseline_memory = self._process.memory_info().rss / (1024 * 1024)
+            self._store.update(
+                {
+                    "timing_measurements": self._step_durations,
+                    "memory_samples": [],
+                    "baseline_memory": baseline_memory,
+                    "process_monitor": self._process,
+                }
+            )
+
+    # MutableMapping interface -------------------------------------------------
+    def __getitem__(self, key: str) -> Any:
+        with self._lock:
+            return self._store[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._store[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        with self._lock:
+            del self._store[key]
+
+    def __iter__(self) -> Iterator[str]:
+        with self._lock:
+            return iter(list(self._store.keys()))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    # Performance tracking helpers --------------------------------------------
+    def start_monitoring(self, session_name: str) -> None:
+        with self._lock:
+            logger.info("Starting performance session: %s", session_name)
+            self._session_name = session_name
+            self._start_time = time.perf_counter()
+            self._step_durations.clear()
+            self._total_steps = 0
+
+    def record_step(self, duration_seconds: float) -> None:
+        with self._lock:
+            if self._session_name is None:
+                return
+            self._step_durations.append(float(duration_seconds))
+            self._total_steps += 1
+
+    def get_metrics(self) -> Dict[str, float | int | str | None]:
+        with self._lock:
+            average = sum(self._step_durations) / len(self._step_durations) if self._step_durations else 0.0
+            maximum = max(self._step_durations) if self._step_durations else 0.0
+            total_runtime = 0.0
+            if self._start_time is not None and self._session_name is not None:
+                total_runtime = time.perf_counter() - self._start_time
+            return {
+                "session": self._session_name,
+                "total_steps": self._total_steps,
+                "average_step_time": average,
+                "max_step_time": maximum,
+                "runtime": total_runtime,
+            }
+
+    def stop_monitoring(self) -> Dict[str, float | int | str | None]:
+        metrics = self.get_metrics()
+        with self._lock:
+            logger.info("Stopping performance session: %s", self._session_name)
+            self._session_name = None
+            self._start_time = None
+            self._step_durations.clear()
+            self._total_steps = 0
+        return metrics
+
+    def reset(self) -> None:
+        with self._lock:
+            logger.debug("Resetting performance tracker state")
+            self._session_name = None
+            self._start_time = None
+            self._step_durations.clear()
+            self._total_steps = 0
+            self._store["timing_measurements"] = self._step_durations
+            self._store.setdefault("memory_samples", []).clear()
+            self._store["baseline_memory"] = self._process.memory_info().rss / (1024 * 1024)
+
+
+class MemoryMonitor:
+    """Track Python heap usage via :mod:`tracemalloc`."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        if not tracemalloc.is_tracing():
+            tracemalloc.start()
+        self._baseline: Optional[tuple[int, int]] = None
+
+    def start_monitoring(self) -> None:
+        with self._lock:
+            self._baseline = tracemalloc.get_traced_memory()
+            logger.debug("Memory baseline captured: %s", self._baseline)
+
+    def stop_monitoring(self) -> Dict[str, float]:
+        with self._lock:
+            current, peak = tracemalloc.get_traced_memory()
+            baseline_current = self._baseline[0] if self._baseline else 0
+            delta = max(0, current - baseline_current)
+            logger.info("Memory usage delta %.2f KB", delta / 1024)
+            return {
+                "memory_mb": current / (1024 * 1024),
+                "peak_memory_mb": peak / (1024 * 1024),
+                "delta_mb": delta / (1024 * 1024),
+                "timestamp": time.time(),
+            }
+
+    def get_current_usage(self) -> Dict[str, float]:
+        with self._lock:
+            current, peak = tracemalloc.get_traced_memory()
+            return {
+                "memory_mb": current / (1024 * 1024),
+                "peak_memory_mb": peak / (1024 * 1024),
+                "timestamp": time.time(),
+            }
+
+
+class CleanupValidator:
+    """Helper that reasons about resource cleanup."""
+
+    def validate(self, before_mb: float, after_mb: float) -> Dict[str, Any]:
+        reclaimed = max(0.0, before_mb - after_mb)
+        logger.debug("Cleanup reclaimed %.4f MB", reclaimed)
+        return {"reclaimed_mb": reclaimed, "cleanup_successful": reclaimed >= 0.0}
+
+    def suggest_actions(self) -> str:
+        return "Release references and invoke gc.collect() to reclaim memory."
+
+
+class TestEnvironmentManager:
+    """Context manager that provisions and tears down test environments."""
+
+    def __init__(self, **config: Any) -> None:
+        self._config = config
+        self._environment: Optional[PlumeSearchEnv] = None
+
+    def __enter__(self) -> PlumeSearchEnv:
+        self._environment = create_plume_search_env(**self._config)
+        logger.info("Provisioned test environment with config: %s", self._config)
+        return self._environment
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._environment is not None:
+            self._environment.close()
+            logger.info("Closed managed environment")
+        self._environment = None
+
+
+@pytest.fixture(scope="session")
+def performance_tracker() -> PerformanceTracker:
+    """Session-wide performance tracker shared across tests."""
+
+    return PerformanceTracker()
+
+
+@pytest.fixture(scope="session")
+def memory_monitor() -> MemoryMonitor:
+    """Provide a shared memory monitor so long-running tests can compare deltas."""
+
+    monitor = MemoryMonitor()
+    monitor.start_monitoring()
+    return monitor
+
+
+@pytest.fixture(scope="session")
+def cleanup_validator() -> CleanupValidator:
+    """Return the cleanup validator utility expected by the tests."""
+
+    return CleanupValidator()
+
+
+@pytest.fixture
+def test_environment_manager() -> TestEnvironmentManager:
+    """Factory fixture returning a new :class:`TestEnvironmentManager`."""
+
+    return TestEnvironmentManager()
+
+
+@pytest.fixture
+def edge_case_test_env(performance_tracker: PerformanceTracker) -> Generator[PlumeSearchEnv, None, None]:
+    """Provision a deterministic environment instrumented for the edge-case suite."""
+
+    environment = create_plume_search_env(grid_size=(64, 64), source_location=(32, 32))
+
+    original_step = environment.step
+
+    def tracked_step(action: Any) -> Any:
+        start = time.perf_counter()
+        result = original_step(action)
+        duration = time.perf_counter() - start
+        performance_tracker.record_step(duration)
+        return result
+
+    environment.step = tracked_step  # type: ignore[assignment]
+
+    try:
+        yield environment
+    finally:
+        environment.close()
+
+
+@pytest.fixture
+def edge_case_fixture() -> Generator[TestEnvironmentManager, None, None]:
+    """Compatibility fixture used by a handful of parametrised tests."""
+
+    manager = TestEnvironmentManager()
+    try:
+        yield manager
+    finally:
+        with contextlib.suppress(Exception):
+            manager.__exit__(None, None, None)
+
+
+@pytest.fixture
+def unit_test_env() -> Generator[PlumeSearchEnv, None, None]:
+    """Lightweight environment instance for unit test scenarios."""
+
+    env = create_plume_search_env(grid_size=(16, 16))
+    try:
+        yield env
+    finally:
+        env.close()
+
+
+@pytest.fixture
+def integration_test_env() -> Generator[PlumeSearchEnv, None, None]:
+    """Environment instance used by integration-style checks."""
+
+    env = create_plume_search_env(grid_size=(24, 24))
+    try:
+        yield env
+    finally:
+        env.close()
+
+
+@pytest.fixture
+def performance_test_env(performance_tracker: PerformanceTracker) -> Generator[PlumeSearchEnv, None, None]:
+    """Environment instrumented for performance tests."""
+
+    env = create_plume_search_env(grid_size=(32, 32))
+    original_step = env.step
+
+    def tracked_step(action: Any) -> Any:
+        start = time.perf_counter()
+        result = original_step(action)
+        duration = time.perf_counter() - start
+        performance_tracker.record_step(duration)
+        return result
+
+    env.step = tracked_step  # type: ignore[assignment]
+
+    try:
+        yield env
+    finally:
+        env.close()
+
+
+@pytest.fixture
+def reproducibility_test_env() -> Generator[PlumeSearchEnv, None, None]:
+    """Environment dedicated to reproducibility checks."""
+
+    env = create_plume_search_env(grid_size=(20, 20))
+    try:
+        yield env
+    finally:
+        env.close()

--- a/src/backend/tests/plume_nav_sim/core/test_episode_manager.py
+++ b/src/backend/tests/plume_nav_sim/core/test_episode_manager.py
@@ -11,17 +11,17 @@ import tempfile  # >=3.10 - Temporary file handling for state persistence testin
 import pathlib  # >=3.10 - Path handling for file operations in testing
 
 # Internal imports from plume_nav_sim core components
-from ....plume_nav_sim.core.episode_manager import (
+from plume_nav_sim.core.episode_manager import (
     EpisodeManager, EpisodeManagerConfig, EpisodeResult, EpisodeStatistics,
     create_episode_manager, validate_episode_config
 )
-from ....plume_nav_sim.core.types import (
+from plume_nav_sim.core.types import (
     Action, Coordinates, AgentState, EpisodeState, EnvironmentConfig,
     create_environment_config, create_coordinates
 )
-from ....plume_nav_sim.core.state_manager import StateManager
-from ....plume_nav_sim.utils.seeding import SeedManager
-from ....plume_nav_sim.utils.exceptions import ValidationError, StateError, ComponentError
+from plume_nav_sim.core.state_manager import StateManager
+from plume_nav_sim.utils.seeding import SeedManager
+from plume_nav_sim.utils.exceptions import ValidationError, StateError, ComponentError
 
 # Global test constants from JSON specification
 TEST_TIMEOUT = 30.0
@@ -1234,7 +1234,7 @@ class TestEpisodeManagerErrorHandling:
             resource_exhaustion_count += 1
             
             if resource_exhaustion_count > 3:
-                from ....plume_nav_sim.utils.exceptions import ResourceError
+                from plume_nav_sim.utils.exceptions import ResourceError
                 raise ResourceError(
                     message="Simulated memory exhaustion during validation",
                     resource_type="memory",

--- a/src/backend/tests/plume_nav_sim/envs/test_base_env.py
+++ b/src/backend/tests/plume_nav_sim/envs/test_base_env.py
@@ -19,13 +19,13 @@ import warnings  # >=3.10 - Warning testing for development feedback, deprecatio
 from contextlib import contextmanager  # >=3.10 - Context manager testing for resource management validation, cleanup testing, and exception handling context testing
 
 # Internal imports for BaseEnvironment and supporting classes
-from ....plume_nav_sim.envs.base_env import (
+from plume_nav_sim.envs.base_env import (
     BaseEnvironment, AbstractEnvironmentError, create_base_environment_config, 
     validate_base_environment_setup
 )
 
 # Core types and data structures for testing
-from ....plume_nav_sim.core.types import (
+from plume_nav_sim.core.types import (
     Action, Coordinates, GridSize, AgentState, EpisodeState, PlumeParameters, 
     EnvironmentConfig, RenderMode, create_coordinates, create_grid_size, 
     create_agent_state, create_environment_config, validate_action, 
@@ -33,7 +33,7 @@ from ....plume_nav_sim.core.types import (
 )
 
 # Exception handling for comprehensive error testing
-from ....plume_nav_sim.utils.exceptions import (
+from plume_nav_sim.utils.exceptions import (
     ValidationError, StateError, ConfigurationError, ComponentError, 
     RenderingError, ErrorSeverity, ErrorContext
 )

--- a/src/backend/tests/plume_nav_sim/render/test_base_renderer.py
+++ b/src/backend/tests/plume_nav_sim/render/test_base_renderer.py
@@ -11,7 +11,7 @@ import threading  # >=3.10 - Thread safety testing for concurrent rendering oper
 from typing import Optional, Dict, Any, List, Union
 
 # Internal imports for BaseRenderer and related components
-from ....plume_nav_sim.render.base_renderer import (
+from plume_nav_sim.render.base_renderer import (
     BaseRenderer, 
     RenderContext, 
     RenderingMetrics,
@@ -19,7 +19,7 @@ from ....plume_nav_sim.render.base_renderer import (
     validate_rendering_parameters,
     create_rendering_metrics
 )
-from ....plume_nav_sim.core.types import (
+from plume_nav_sim.core.types import (
     RenderMode, 
     Coordinates, 
     GridSize, 
@@ -28,13 +28,13 @@ from ....plume_nav_sim.core.types import (
     create_grid_size,
     calculate_euclidean_distance
 )
-from ....plume_nav_sim.core.constants import (
+from plume_nav_sim.core.constants import (
     PERFORMANCE_TARGET_RGB_RENDER_MS,
     PERFORMANCE_TARGET_HUMAN_RENDER_MS,
     FIELD_DTYPE,
     RGB_DTYPE
 )
-from ....plume_nav_sim.utils.exceptions import (
+from plume_nav_sim.utils.exceptions import (
     ValidationError,
     RenderingError,
     ComponentError

--- a/src/backend/tests/plume_nav_sim/render/test_matplotlib_viz.py
+++ b/src/backend/tests/plume_nav_sim/render/test_matplotlib_viz.py
@@ -31,18 +31,18 @@ from typing import Dict, List, Optional, Union, Any, Tuple  # >=3.10 - Type hint
 from unittest.mock import Mock, patch, MagicMock, call  # >=3.10 - Mock objects for comprehensive testing scenarios
 
 # Internal imports from plume_nav_sim modules
-from ....plume_nav_sim.render.matplotlib_viz import (
+from plume_nav_sim.render.matplotlib_viz import (
     MatplotlibRenderer, MatplotlibBackendManager, InteractiveUpdateManager,
     create_matplotlib_renderer, detect_matplotlib_capabilities, configure_matplotlib_backend,
     validate_matplotlib_integration
 )
-from ....plume_nav_sim.render.base_renderer import BaseRenderer, RenderContext, create_render_context
-from ....plume_nav_sim.render.color_schemes import CustomColorScheme, get_default_scheme, create_accessibility_scheme
-from ....plume_nav_sim.core.types import RenderMode, Coordinates, GridSize
-from ....plume_nav_sim.core.constants import (
+from plume_nav_sim.render.base_renderer import BaseRenderer, RenderContext, create_render_context
+from plume_nav_sim.render.color_schemes import CustomColorScheme, get_default_scheme, create_accessibility_scheme
+from plume_nav_sim.core.types import RenderMode, Coordinates, GridSize
+from plume_nav_sim.core.constants import (
     PERFORMANCE_TARGET_HUMAN_RENDER_MS, MATPLOTLIB_DEFAULT_FIGSIZE, BACKEND_PRIORITY_LIST
 )
-from ....plume_nav_sim.utils.exceptions import ValidationError, RenderingError
+from plume_nav_sim.utils.exceptions import ValidationError, RenderingError
 
 # Global test constants for consistent test execution
 MATPLOTLIB_AVAILABLE = True  # Flag indicating matplotlib availability for test setup

--- a/src/backend/tests/test_edge_cases.py
+++ b/src/backend/tests/test_edge_cases.py
@@ -22,20 +22,25 @@ import sys  # standard library - System utilities for testing system limit edge 
 import math  # standard library - Mathematical utilities for edge case calculations
 
 # Internal imports - core environment and utilities
-from ..conftest import (
-    edge_case_test_env, test_environment_manager, performance_tracker, 
-    memory_monitor, cleanup_validator
+from .conftest import (
+    edge_case_test_env,
+    test_environment_manager,
+    performance_tracker,
+    memory_monitor,
+    cleanup_validator,
+    matplotlib_available,
+    single_threaded_only,
 )
-from ..plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
-from ..plume_nav_sim.utils.validation import (
-    validate_environment_config, validate_action_parameter, validate_coordinates, 
+from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
+from plume_nav_sim.utils.validation import (
+    validate_environment_config, validate_action_parameter, validate_coordinates,
     ParameterValidator
 )
-from ..plume_nav_sim.utils.exceptions import (
+from plume_nav_sim.utils.exceptions import (
     ValidationError, StateError, RenderingError, ConfigurationError, ResourceError
 )
-from ..plume_nav_sim.core.boundary_enforcer import BoundaryEnforcer
-from ..plume_nav_sim.core.types import Action, Coordinates
+from plume_nav_sim.core.boundary_enforcer import BoundaryEnforcer
+from plume_nav_sim.core.types import Action, Coordinates
 
 # Global constants for edge case testing parameters
 EDGE_CASE_TIMEOUT_SECONDS = 30.0
@@ -78,12 +83,12 @@ class EdgeCaseTestFixture:
         self.error_scenarios = {}
         
         # Create PerformanceTracker instance for monitoring edge case performance impact
-        from ..conftest import performance_tracker
-        self.performance_tracker = performance_tracker
-        
+        from tests.conftest import PerformanceTracker as _PerformanceTracker
+        self.performance_tracker = _PerformanceTracker()
+
         # Initialize MemoryMonitor for detecting resource issues during edge case execution
-        from ..conftest import memory_monitor
-        self.memory_monitor = memory_monitor
+        from tests.conftest import MemoryMonitor as _MemoryMonitor
+        self.memory_monitor = _MemoryMonitor()
     
     def create_extreme_environment(self, edge_case_type: str, custom_params: dict = None) -> PlumeSearchEnv:
         """

--- a/src/backend/tests/test_integration.py
+++ b/src/backend/tests/test_integration.py
@@ -1,0 +1,85 @@
+"""Integration smoke tests for the lightweight plume navigation environment."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from plume_nav_sim.envs.plume_search_env import create_plume_search_env
+
+
+class TestEnvironmentIntegration:
+    """Pytest-style class wrapper exposing integration smoke tests."""
+
+    def test_complete_episode_workflow(self) -> None:
+        test_complete_episode_workflow()
+
+    def test_cross_component_seeding(self) -> None:
+        test_cross_component_seeding()
+
+    def test_system_level_performance(self) -> None:
+        test_system_level_performance()
+
+
+def test_complete_episode_workflow() -> None:
+    """Run a short deterministic episode to validate Gymnasium-style behaviour."""
+
+    env = create_plume_search_env(grid_size=(16, 16), source_location=(8, 8), max_steps=5, goal_radius=0)
+    try:
+        observation, info = env.reset(seed=21)
+        assert observation.shape == (3,), "Reset should return compact observation vector"
+        assert info["agent_xy"]
+
+        total_steps = 0
+        terminated = truncated = False
+        while not (terminated or truncated):
+            observation, reward, terminated, truncated, info = env.step(total_steps % 4)
+            total_steps += 1
+            assert observation.shape == (3,)
+            assert isinstance(reward, float)
+
+        assert total_steps <= 5, "Episode should respect the configured max_steps"
+    finally:
+        env.close()
+
+
+def test_cross_component_seeding() -> None:
+    """Ensure seeding produces identical trajectories across environment instances."""
+
+    env_a = create_plume_search_env(grid_size=(12, 12))
+    env_b = create_plume_search_env(grid_size=(12, 12))
+    try:
+        obs_a, info_a = env_a.reset(seed=99)
+        obs_b, info_b = env_b.reset(seed=99)
+
+        assert np.allclose(obs_a, obs_b)
+        assert info_a["agent_xy"] == info_b["agent_xy"]
+
+        trajectory_a = [env_a.step(0) for _ in range(3)]
+        trajectory_b = [env_b.step(0) for _ in range(3)]
+
+        for step_a, step_b in zip(trajectory_a, trajectory_b):
+            np.testing.assert_allclose(step_a[0], step_b[0])
+            assert step_a[1:] == step_b[1:]
+    finally:
+        env_a.close()
+        env_b.close()
+
+
+def test_system_level_performance() -> None:
+    """Exercise rendering pathways to ensure they remain callable in integration flows."""
+
+    env = create_plume_search_env(grid_size=(8, 8))
+    try:
+        env.reset(seed=7)
+        rgb = env.render(mode="rgb_array")
+        assert rgb.shape == (8, 8, 3)
+        assert rgb.dtype == np.uint8
+
+        try:
+            env.render(mode="human")
+        except Exception:
+            # If the interactive backend is unavailable, ensure the fallback path still returns an array.
+            fallback = env.render(mode="rgb_array")
+            assert fallback is not None
+    finally:
+        env.close()

--- a/src/backend/tests/test_performance.py
+++ b/src/backend/tests/test_performance.py
@@ -30,11 +30,11 @@ import time  # >=3.10 - High-precision timing measurements using perf_counter fo
 import warnings  # >=3.10 - Warning management for performance test execution and deprecation handling
 
 # Internal imports for environment benchmarking and comprehensive performance analysis
-from ..plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
-from ..benchmarks.environment_performance import (
+from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
+from benchmarks.environment_performance import (
     run_environment_performance_benchmark,
     benchmark_step_latency,
-    benchmark_episode_performance, 
+    benchmark_episode_performance,
     benchmark_memory_usage,
     benchmark_rendering_performance,
     validate_performance_targets,
@@ -43,7 +43,7 @@ from ..benchmarks.environment_performance import (
     EnvironmentBenchmarkConfig,
     BenchmarkResult
 )
-from ..plume_nav_sim.core.constants import (
+from plume_nav_sim.core.constants import (
     PERFORMANCE_TARGET_STEP_LATENCY_MS,
     PERFORMANCE_TARGET_RGB_RENDER_MS,  
     PERFORMANCE_TARGET_PLUME_GENERATION_MS,

--- a/src/backend/tests/test_rendering.py
+++ b/src/backend/tests/test_rendering.py
@@ -31,14 +31,14 @@ import tempfile  # >=3.10 - Temporary file management for testing figure saving,
 from typing import Dict, List, Tuple, Optional, Any, Union  # >=3.10 - Type annotations for comprehensive test validation and parameter specification
 
 # Internal imports - Environment and rendering components
-from ..plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
-from ..plume_nav_sim.render.numpy_rgb import NumpyRGBRenderer
-from ..plume_nav_sim.render.matplotlib_viz import MatplotlibRenderer, detect_matplotlib_capabilities, configure_matplotlib_backend
-from ..plume_nav_sim.render.base_renderer import BaseRenderer, RenderContext, create_render_context, RenderingMetrics
+from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
+from plume_nav_sim.render.numpy_rgb import NumpyRGBRenderer
+from plume_nav_sim.render.matplotlib_viz import MatplotlibRenderer, detect_matplotlib_capabilities, configure_matplotlib_backend
+from plume_nav_sim.render.base_renderer import BaseRenderer, RenderContext, create_render_context, RenderingMetrics
 
 # Internal imports - Core types and constants
-from ..plume_nav_sim.core.types import RenderMode, Coordinates, GridSize
-from ..plume_nav_sim.core.constants import (
+from plume_nav_sim.core.types import RenderMode, Coordinates, GridSize
+from plume_nav_sim.core.constants import (
     PERFORMANCE_TARGET_RGB_RENDER_MS,  # Performance target (<5ms) for RGB array rendering benchmark validation in integration tests
     PERFORMANCE_TARGET_HUMAN_RENDER_MS,  # Performance target (<50ms) for human mode rendering benchmark validation in integration tests
     SUPPORTED_RENDER_MODES,  # Supported render mode list for testing mode validation and compatibility


### PR DESCRIPTION
## Summary
- add a pytest-friendly integration wrapper so the new smoke tests collect with the real environment
- expose matplotlib/threading feature flags and a mapping-compatible performance tracker from tests.conftest
- implement the PerformanceAnalysis helper expected by the performance suite and center the default source location for small grids

## Testing
- pytest src/backend/tests/test_integration.py
- pytest src/backend/tests/test_edge_cases.py -k rendering_edge_cases_and_failures


------
https://chatgpt.com/codex/tasks/task_e_68cb6a5a8c748320abd625bf856f0376