### PR TITLE
test: fail loudly when backend dependencies missing

### DIFF
--- a/src/backend/tests/__init__.py
+++ b/src/backend/tests/__init__.py
@@ -37,32 +37,9 @@ try:  # pragma: no cover - import guard for optional fixtures
         TestEnvironmentManager, PerformanceTracker
     )
 except ModuleNotFoundError as exc:  # pragma: no cover - exercised only in minimal kata builds
-    def _missing_fixture(*_args: Any, **_kwargs: Any):  # type: ignore[override]
-        pytest.skip(
-            "Comprehensive environment fixtures are unavailable in the kata sandbox."
-        )
-
-    unit_test_env = integration_test_env = performance_test_env = reproducibility_test_env = _missing_fixture  # type: ignore[assignment]
-
-    class TestEnvironmentManager:  # type: ignore[override]
-        """Fallback stub used when the full test harness is absent."""
-
-        def __enter__(self) -> "TestEnvironmentManager":
-            pytest.skip("Test environment manager not available in this build.")
-            return self
-
-        def __exit__(self, *_exc: Any) -> None:
-            return None
-
-    class PerformanceTracker:  # type: ignore[override]
-        """Fallback stub used when the full test harness is absent."""
-
-        def __enter__(self) -> "PerformanceTracker":
-            pytest.skip("Performance tracking not available in this build.")
-            return self
-
-        def __exit__(self, *_exc: Any) -> None:
-            return None
+    raise ImportError(
+        "Required test fixtures are missing; ensure src/backend/tests/conftest.py is available."
+    ) from exc
 
 # Internal imports - Main test classes and functions from test modules
 try:  # pragma: no cover - import guard for optional API compliance tests
@@ -76,16 +53,9 @@ try:  # pragma: no cover - import guard for optional API compliance tests
         test_seeding_and_reproducibility
     )
 except ModuleNotFoundError as exc:  # pragma: no cover - exercised only in minimal kata builds
-    TestEnvironmentAPI = None  # type: ignore[assignment]
-
-    def test_environment_inheritance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Environment API tests are unavailable in this minimal environment.")
-
-    def test_gymnasium_api_compliance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Environment API tests are unavailable in this minimal environment.")
-
-    def test_seeding_and_reproducibility(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Environment API tests are unavailable in this minimal environment.")
+    raise ImportError(
+        "Environment API tests are unavailable; ensure test_environment_api.py is present."
+    ) from exc
 
 # Performance modules are optional in the pared-down kata repository.  Guard the imports
 # so we can still run lightweight contract tests without the heavy Gymnasium dependency
@@ -101,17 +71,9 @@ try:  # pragma: no cover - import guard for optional performance tests
         test_comprehensive_performance_suite
     )
 except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover - exercised only in minimal kata builds
-    warnings.warn(f"Performance test suite could not be imported: {exc}")
-    TestPerformanceValidation = None  # type: ignore[assignment]
-
-    def test_environment_step_latency_performance(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Performance tests are unavailable in this minimal environment.")
-
-    def test_memory_usage_constraints(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Performance tests are unavailable in this minimal environment.")
-
-    def test_comprehensive_performance_suite(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
-        pytest.skip("Performance tests are unavailable in this minimal environment.")
+    raise ImportError(
+        "Performance test suite could not be imported; ensure test_performance.py and its dependencies are available."
+    ) from exc
 
 try:  # pragma: no cover - import guard for optional integration tests
     from .test_integration import (

--- a/src/backend/tests/test_performance.py
+++ b/src/backend/tests/test_performance.py
@@ -21,6 +21,7 @@ failure analysis including component-specific recommendations for development op
 # External imports with version requirements for comprehensive testing framework
 import contextlib  # >=3.10 - Context managers for resource isolation and performance measurement
 import gc  # >=3.10 - Garbage collection control for memory leak detection and baseline measurement
+import logging  # >=3.10 - Structured logging for fail-fast diagnostics during performance test import
 import numpy as np  # >=2.1.0 - Statistical analysis and performance data processing for benchmark validation
 import pytest  # >=8.0.0 - Testing framework with fixtures, parametrization, and comprehensive execution support
 import statistics  # >=3.10 - Statistical functions for performance metric calculation and confidence intervals
@@ -31,28 +32,32 @@ import warnings  # >=3.10 - Warning management for performance test execution an
 # Internal imports for environment benchmarking and comprehensive performance analysis
 from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env
 
-psutil = pytest.importorskip(
-    "psutil",
-    reason="psutil is required for performance benchmark validation",
-)
+LOGGER = logging.getLogger(__name__)
 
-pytest.importorskip(
-    "benchmarks.environment_performance",
-    reason="Performance benchmark module is required",
-)
+try:
+    import psutil  # type: ignore[import-not-found] - validated at runtime
+except ImportError as exc:  # pragma: no cover - failure handled immediately
+    _MESSAGE = "psutil is required for performance benchmark validation"
+    LOGGER.error(_MESSAGE)
+    raise RuntimeError(_MESSAGE) from exc
 
-from benchmarks.environment_performance import (
-    run_environment_performance_benchmark,
-    benchmark_step_latency,
-    benchmark_episode_performance,
-    benchmark_memory_usage,
-    benchmark_rendering_performance,
-    validate_performance_targets,
-    EnvironmentPerformanceSuite,
-    PerformanceAnalysis,
-    EnvironmentBenchmarkConfig,
-    BenchmarkResult
-)
+try:
+    from benchmarks.environment_performance import (
+        run_environment_performance_benchmark,
+        benchmark_step_latency,
+        benchmark_episode_performance,
+        benchmark_memory_usage,
+        benchmark_rendering_performance,
+        validate_performance_targets,
+        EnvironmentPerformanceSuite,
+        PerformanceAnalysis,
+        EnvironmentBenchmarkConfig,
+        BenchmarkResult
+    )
+except ImportError as exc:  # pragma: no cover - failure handled immediately
+    _MESSAGE = "Performance benchmark module is required"
+    LOGGER.error(_MESSAGE)
+    raise RuntimeError(_MESSAGE) from exc
 from plume_nav_sim.core.constants import (
     PERFORMANCE_TARGET_STEP_LATENCY_MS,
     PERFORMANCE_TARGET_RGB_RENDER_MS,  

--- a/tests/test_backend_import_failures.py
+++ b/tests/test_backend_import_failures.py
@@ -1,0 +1,58 @@
+"""Regression tests ensuring backend test suite fails fast when dependencies are missing."""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from _pytest.outcomes import Skipped
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+BACKEND_SRC = SRC_ROOT / "backend"
+
+for path in (PROJECT_ROOT, SRC_ROOT, BACKEND_SRC):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_performance_module_missing_psutil_is_error(monkeypatch):
+    """Importing the performance tests without psutil should raise instead of skipping."""
+    module_name = "src.backend.tests.test_performance"
+    sys.modules.pop(module_name, None)
+
+    # Make sure psutil import fails loudly.
+    monkeypatch.setitem(sys.modules, "psutil", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        try:
+            importlib.import_module(module_name)
+        except Skipped as skipped_exc:  # pragma: no cover - triggers red phase
+            raise AssertionError("performance tests should fail, not skip, when psutil is missing") from skipped_exc
+
+    assert "psutil" in str(excinfo.value)
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_tests_package_missing_conftest_raises(monkeypatch):
+    """If the shared conftest module is unavailable, importing the package should raise."""
+    package_name = "src.backend.tests"
+    sys.modules.pop(package_name, None)
+    sys.modules.pop(f"{package_name}.conftest", None)
+
+    stub_psutil = types.ModuleType("psutil")
+    stub_psutil.Process = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "psutil", stub_psutil)
+
+    broken_conftest = types.ModuleType(f"{package_name}.conftest")
+    monkeypatch.setitem(sys.modules, f"{package_name}.conftest", broken_conftest)
+
+    with pytest.raises(ImportError):
+        try:
+            importlib.import_module(package_name)
+        except Skipped as skipped_exc:  # pragma: no cover - triggers red phase
+            raise AssertionError("tests package should fail loudly when conftest is missing") from skipped_exc


### PR DESCRIPTION
## Summary
- add regression tests that verify backend tests raise errors when critical dependencies are absent instead of silently skipping
- change backend test package initialization to raise explicit ImportError when conftest, API, or performance suites are missing
- update performance tests to log and raise RuntimeError when psutil or benchmark helpers are unavailable

## Testing
- `pytest tests/test_backend_import_failures.py -q`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ccb6194be48320ae42aaabdea97b5f