### PR TITLE
fix: raise loud errors for trimmed test harness

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -20,13 +20,15 @@ except ImportError:  # pragma: no cover - dependency may be unavailable in light
 
 
 def _require_psutil() -> "psutil":
-    """Return the real :mod:`psutil` module or skip dependent fixtures."""
+    """Return the real :mod:`psutil` module or fail loudly when unavailable."""
 
     if _psutil is None:
-        pytest.skip(
-            "psutil is required for performance monitoring fixtures",
-            allow_module_level=False,
+        message = (
+            "psutil is required for performance monitoring fixtures; install psutil to run "
+            "the trimmed performance suite."
         )
+        logging.getLogger(__name__).error(message)
+        raise RuntimeError(message)
     return _psutil
 
 from plume_nav_sim.envs.plume_search_env import PlumeSearchEnv, create_plume_search_env

--- a/src/backend/tests/plume_nav_sim/__init__.py
+++ b/src/backend/tests/plume_nav_sim/__init__.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
-import pytest
+import logging
 
 __all__ = ["require_full_test_suite"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 def require_full_test_suite() -> None:
-    """Signal that the expansive upstream test helpers are not bundled."""
+    """Raise an explicit error indicating the trimmed test harness."""
 
-    pytest.skip(
-        "The full plume_nav_sim test harness is not included in this kata-oriented repository."
+    message = (
+        "The full plume_nav_sim test suite is not included in this kata repository; "
+        "install the upstream test harness to exercise these helpers."
     )
+    _LOGGER.error(message)
+    raise RuntimeError(message)

--- a/src/backend/tests/plume_nav_sim/render/__init__.py
+++ b/src/backend/tests/plume_nav_sim/render/__init__.py
@@ -1,3 +1,18 @@
 """Render-specific tests namespace stub for the trimmed test environment."""
 
+from __future__ import annotations
+
+import logging
+
 __all__: list[str] = []
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def __getattr__(name: str):
+    message = (
+        f"Render test helper '{name}' is not included in the trimmed plume_nav_sim test suite. "
+        "Install the full test harness to access render-specific fixtures."
+    )
+    _LOGGER.error(message)
+    raise AttributeError(message)

--- a/tests/test_trimmed_suite_guardrails.py
+++ b/tests/test_trimmed_suite_guardrails.py
@@ -1,0 +1,94 @@
+"""Tests ensuring trimmed test suite surfaces missing dependencies loudly."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+BACKEND_SRC_DIR = SRC_DIR / "backend"
+for path in (SRC_DIR, BACKEND_SRC_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+def _load_module(module_name: str, relative_path: str) -> ModuleType:
+    """Load a module from the src tree without triggering package side effects."""
+
+    full_path = SRC_DIR / relative_path
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, full_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"Unable to load module spec for {module_name} from {full_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_require_psutil_fails_loud_when_unavailable(monkeypatch):
+    """_require_psutil should raise a loud failure when psutil is missing."""
+
+    conftest = _load_module("trimmed_conftest", "backend/tests/conftest.py")
+    original_psutil = getattr(conftest, "_psutil", None)
+    monkeypatch.setattr(conftest, "_psutil", None, raising=False)
+    monkeypatch.setattr(
+        conftest.pytest,
+        "skip",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("skip invoked")),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        conftest._require_psutil()
+
+    message = str(excinfo.value)
+    assert "psutil" in message
+    assert "performance" in message.lower()
+
+    if original_psutil is not None:
+        monkeypatch.setattr(conftest, "_psutil", original_psutil, raising=False)
+
+
+def test_require_full_test_suite_raises_instead_of_skip(monkeypatch):
+    """The trimmed suite hook should raise an explicit error instead of skipping."""
+
+    module = _load_module(
+        "trimmed_plume_nav_sim_tests",
+        "backend/tests/plume_nav_sim/__init__.py",
+    )
+    if hasattr(module, "pytest"):
+        monkeypatch.setattr(
+            module.pytest,
+            "skip",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("skip invoked")),
+        )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module.require_full_test_suite()
+
+    message = str(excinfo.value).lower()
+    assert "full" in message
+    assert "test" in message
+    assert "suite" in message
+
+
+def test_render_namespace_access_is_informative():
+    """Attempting to access trimmed render helpers should raise a descriptive error."""
+
+    module = _load_module(
+        "trimmed_plume_nav_sim_render",
+        "backend/tests/plume_nav_sim/render/__init__.py",
+    )
+
+    with pytest.raises(AttributeError) as excinfo:
+        getattr(module, "nonexistent_helper")
+
+    message = str(excinfo.value).lower()
+    assert "render" in message
+    assert "not included" in message


### PR DESCRIPTION
## Summary
- add regression tests that ensure missing psutil and trimmed test helpers fail loudly
- raise explicit runtime errors when psutil or the full plume_nav_sim test harness is unavailable
- provide descriptive render namespace attribute errors with logging for missing helpers

## Testing
- pytest tests/test_trimmed_suite_guardrails.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7d11e1648320bd9bbc36417627d9