### PR TITLE
feat(registration): component-based env default; registration/env fixes; DI docs

### DIFF
--- a/src/backend/tests/integration/test_registration_unified.py
+++ b/src/backend/tests/integration/test_registration_unified.py
@@ -23,19 +23,19 @@ def _get_entry_point_string(env_id: str) -> str:
     return str(ep)
 
 
-def test_register_legacy_entry_point():
+def test_register_component_entry_point_default():
     # Ensure clean state
     unregister_env(ENV_ID, suppress_warnings=True)
-    # Default registration uses legacy PlumeSearchEnv
+    # Default registration uses component-based environment via factory
     register_env(force_reregister=True)
     entry_point = _get_entry_point_string(ENV_ID)
-    assert "plume_nav_sim.envs.plume_search_env:PlumeSearchEnv" in entry_point
+    assert "plume_nav_sim.envs.factory:create_component_environment" in entry_point
 
 
-def test_register_component_entry_point_flag():
+def test_register_legacy_entry_point_flag():
     # Ensure clean state
     unregister_env(ENV_ID, suppress_warnings=True)
-    # Register with the component-based flag
-    register_env(kwargs={"use_components": True}, force_reregister=True)
+    # Register with explicit legacy toggle
+    register_env(use_legacy=True, force_reregister=True)
     entry_point = _get_entry_point_string(ENV_ID)
-    assert "plume_nav_sim.envs.component_env:ComponentBasedEnvironment" in entry_point
+    assert "plume_nav_sim.envs.plume_search_env:PlumeSearchEnv" in entry_point


### PR DESCRIPTION
## Summary
This PR makes the component‑based (dependency injection) environment the default, removes the old use_components flag, adds a narrow use_legacy toggle for explicit fallback, fixes registration/env issues uncovered by tests, and ships public docs for composing environments from components.

## Changes
- Default entry point → `plume_nav_sim.envs.factory:create_component_environment`
- Removed `use_components` flag; added `use_legacy=True` to select legacy `PlumeSearchEnv` explicitly
- Registration fixes
  - Pass `max_episode_steps` to registry and validation
  - Stricter `env_id` + `entry_point` validation (strict mode warns on import/missing class)
  - `create_registration_kwargs`: None‑only defaults; `source_location` defaults to grid center
  - Better `ValidationError` details (expected_format for grid_size)
  - Memory test stabilization by avoiding preloaded `gc` and popping after `unregister_env`
  - Minor cache‑hit logging optimization
- Env/Spaces
  - PlumeSearchEnv returns a Box observation and avoids super().reset() on the local Gymnasium shim (prevents NotImplementedError)
  - Local Gymnasium shim: `Space.__contains__`, `Discrete.seed()` and `sample()` for deterministic sampling
- Docs
  - New: `docs/extending/component_injection.md` (public API: env_state schema, factory/registration/manual wiring examples)
  - New: `docs/extending/README.md` (extensions index)
  - README: component‑based environment usage and registration notes
  - Contracts: `component_interfaces.md` (env_state), `reward_function_interface.md` (StepPenaltyReward independent of step_count)
- Tests
  - Integration assertions updated: default → factory entry point; legacy via `use_legacy=True`
- Pytest
  - Registered `api_compliance` mark; suppressed informational Gymnasium shim warning

## Rationale
- DI‑first default reduces cruft and aligns with the pluggable architecture: actions, observations, rewards are composed, not hardcoded.
- Legacy path remains available behind an explicit toggle to ease migration (can be removed later).

## Validation
- Registration test suite fully green locally
- Pre‑commit hooks (black, isort, bandit, etc.) run clean on push
- Manual sanity checks for `gym.make`, DI factory, and registration flows

## Backward Compatibility
- Default behavior shifts to components; legacy available via `use_legacy=True`
- No break for direct imports of `PlumeSearchEnv` (still present)

## Follow‑ups (optional)
- Micro benchmark test for DI overhead (expected negligible)
- Consider a dedicated env_id for the component env to avoid toggles in the long term

## Checklist
- [x] Tests pass locally
- [x] Docs updated (README, contracts, extending/*)
- [x] BC toggle for legacy provided
